### PR TITLE
Add PersonAccount to whitelist

### DIFF
--- a/build/whitelists/metadata.txt
+++ b/build/whitelists/metadata.txt
@@ -254,6 +254,7 @@ PartnerRole.object
 Period.object
 PermissionSet.object
 PermissionSetAssignment.object
+PersonAccount.object
 Pricebook2.object
 Pricebook2History.object
 PricebookEntry.object


### PR DESCRIPTION
This fixes the issue where calls to the ant target "uninstallUnpackagedPost" will fail if unpackaged/post contains PersonAccount.object (error: "The CustomObject called 'PersonAccount' is standard and cannot be deleted")