### PR TITLE
Added CustomMetadata for DestructiveChanges.xml Creation

### DIFF
--- a/build/cumulusci.xml
+++ b/build/cumulusci.xml
@@ -370,6 +370,9 @@ project.setProperty("downgradePackage", result);
             <case value="letterhead">
               <property name="typename" value="Letterhead" />
             </case>
+            <case value="customMetadata">
+              <property name="typename" value="CustomMetadata" />
+            </case>
             <default/>
           </switch>
 


### PR DESCRIPTION
Working a lot with CMDTs and had some stragglers that were not deleting.  Looks like it was never set up to recognize them.  Adding the included change made it all work without further changes, for me.