### PR TITLE
Use the sf.serverurl when getting the package versions

### DIFF
--- a/build/build.xml
+++ b/build/build.xml
@@ -557,6 +557,7 @@
             <sf:bulkRetrieve
                 username="${sf.username}"
                 password="${sf.password}"
+                serverurl="${sf.serverurl}"
                 metadataType="InstalledPackage"
                 retrieveTarget="${basedir}/installedPackages"/>
     


### PR DESCRIPTION
updated the  getPackageVersions macro to use the sf.serverurl parameter.
