### PR TITLE
buildPackagedDestructiveChanges to edit package.xml

### DIFF
--- a/build/cumulusci.xml
+++ b/build/cumulusci.xml
@@ -819,7 +819,7 @@ project.setProperty("downgradePackage", result);
 </Package>]]></echo>
 
       <!-- Add the package name to the package.xml file -->
-      <replaceregexp file="@{xmlfile}" match="Package(.*)>" replace="Package\1>&lt;fullName>@{package}%lt;/fullName>${line-separator}" />
+      <replaceregexp file="@{dir}/package.xml" match="Package(.*)>" replace="Package\1>&lt;fullName>@{package}&lt;/fullName>${line-separator}" />
 
       <!-- Build the destructiveChanges.xml file by walking the srcdir and adding all metadata -->
       <!-- Exclude CustomLabels.labels so we can use addMetadataSubType on it instead -->


### PR DESCRIPTION
currently, buildPackagedDestructiveChanges is injecting the package name into package.xml with @xmlfile, and arg not explicitly defined in this macrodef. It must be getting passed in in some way that I don't fully understand. This changes the regexpreplace to explicitly edit package.xml

As an aside, I'm not entirely sure why the package.xml is built from strings and then immediately modified, so this patch may better be replaced with echoing the package name directly into the file? But I didn't want to spend too much time editing this when I'm still not one hundred on how ant works.
