### PR TITLE
package.xml generation fixes

### DIFF
--- a/cli/metadata/tests/package_metadata/namespaced_report_folder/destructiveChanges.xml
+++ b/cli/metadata/tests/package_metadata/namespaced_report_folder/destructiveChanges.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Package xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Test Package</fullName>
+    <types>
+        <members>namespace__TestFolder/TestReport</members>
+        <name>Report</name>
+    </types>
+    <version>36.0</version>
+</Package>

--- a/cli/metadata/tests/package_metadata/namespaced_report_folder/package.xml
+++ b/cli/metadata/tests/package_metadata/namespaced_report_folder/package.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Package xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Test Package</fullName>
+    <types>
+        <members>namespace__TestFolder/TestReport</members>
+        <name>Report</name>
+    </types>
+    <version>36.0</version>
+</Package>

--- a/cli/metadata/tests/package_metadata/namespaced_report_folder/reports/namespace__TestFolder/TestReport.report
+++ b/cli/metadata/tests/package_metadata/namespaced_report_folder/reports/namespace__TestFolder/TestReport.report
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Report xmlns="http://soap.sforce.com/2006/04/metadata">
+</Report>

--- a/cli/metadata/tests/test_package.py
+++ b/cli/metadata/tests/test_package.py
@@ -1,0 +1,62 @@
+import os
+import tempfile
+import unittest
+
+from metadata.package import PackageXmlGenerator
+
+__location__ = os.path.split(os.path.realpath(__file__))[0]
+
+class TestPackageXmlGenerator(unittest.TestCase):
+
+    def test_package_name_urlencoding(self):
+        api_version = '36.0'
+        package_name = 'Test & Package'
+        path = tempfile.mkdtemp()
+
+        expected = '<?xml version="1.0" encoding="UTF-8"?>\n'
+        expected += '<Package xmlns="http://soap.sforce.com/2006/04/metadata">\n'
+        expected += '    <fullName>Test %26 Package</fullName>\n'
+        expected += '    <version>{}</version>\n'.format(api_version)
+        expected += '</Package>'
+        
+        generator = PackageXmlGenerator(path, api_version, package_name)
+        package_xml = generator()
+
+        self.assertEquals(package_xml, expected)
+        
+    
+    def test_namespaced_report_folder(self):
+        api_version = '36.0'
+        package_name = 'Test Package'
+        test_dir = 'namespaced_report_folder'
+
+        path = os.path.join(
+            __location__,
+            'package_metadata',
+            test_dir,
+        )
+
+        generator = PackageXmlGenerator(path, api_version, package_name)
+        expected_package_xml = open(os.path.join(path, 'package.xml'), 'r')
+        expected_package_xml = expected_package_xml.read().strip()
+        package_xml = generator()
+
+        self.assertEquals(package_xml, expected_package_xml)
+
+    def test_delete_namespaced_report_folder(self):
+        api_version = '36.0'
+        package_name = 'Test Package'
+        test_dir = 'namespaced_report_folder'
+
+        path = os.path.join(
+            __location__,
+            'package_metadata',
+            test_dir,
+        )
+
+        generator = PackageXmlGenerator(path, api_version, package_name, delete=True)
+        expected_package_xml = open(os.path.join(path, 'destructiveChanges.xml'), 'r')
+        expected_package_xml = expected_package_xml.read().strip()
+        package_xml = generator()
+
+        self.assertEquals(package_xml, expected_package_xml)


### PR DESCRIPTION
- Create tests structure for PackageXmlGenerator
- use urllib.quote to escape the package name to handle &'s in the
  package name
- Don't include namespaced report/dashboard folders in package.xml