### PR TITLE
Feature/project name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ dist/
 .eggs/
 .idea/
 .tox/
+tags
+.vscode/

--- a/cumulusci/core/config.py
+++ b/cumulusci/core/config.py
@@ -270,10 +270,23 @@ class BaseProjectConfig(BaseTaskFlowConfig):
 
     @property
     def project_local_dir(self):
+        """ location of the user local directory for the project
+        e.g., ~/.cumulusci/NPSP-Extension-Test/ """
+
+        # depending on where we are in bootstrapping the YamlGlobalConfig
+        # the canonical projectname could be located in one of two places
+        if self.project__name:
+            name = self.project__name
+        else:
+            try:
+                name = self.config_project['project']['name']
+            except KeyError:
+                name = ''
+
         path = os.path.join(
             os.path.expanduser('~'),
             self.global_config_obj.config_local_dir,
-            self.repo_name,
+            name,
         )
         if not os.path.isdir(path):
             os.makedirs(path)

--- a/cumulusci/core/tests/test_config.py
+++ b/cumulusci/core/tests/test_config.py
@@ -196,6 +196,7 @@ class TestYamlProjectConfig(unittest.TestCase):
         )
         content = (
             'project:\n' +
+            '    name: TestRepo\n' +
             '    package:\n' +
             '        name: TestProject\n' +
             '        namespace: testproject\n'
@@ -323,7 +324,7 @@ class TestYamlProjectConfig(unittest.TestCase):
         content = (
             'project:\n' +
             '    package:\n' +
-            '        name: TestProject2\n'
+            '        api_version: 10\n'
         )
         self._create_project_config_local(content)
 
@@ -331,5 +332,4 @@ class TestYamlProjectConfig(unittest.TestCase):
         global_config = YamlGlobalConfig()
         config = YamlProjectConfig(global_config)
         self.assertNotEqual(config.config_project_local, {})
-        self.assertEqual(config.project__package__name, 'TestProject2')
-        self.assertEqual(config.project__package__namespace, 'testproject')
+        self.assertEqual(config.project__package__api_version, 10)

--- a/cumulusci/core/tests/test_keychain.py
+++ b/cumulusci/core/tests/test_keychain.py
@@ -39,6 +39,7 @@ class TestBaseProjectKeychain(unittest.TestCase):
             'mrbelvedere':{'attributes':{'mr':{'required':True}}},
             'apextestsdb':{'attributes':{'apex':{'required':True}}},
         }
+        self.project_config.config['name'] = 'TestProject'
         self.connected_app_config = ConnectedAppOAuthConfig({'test': 'value'})
         self.services = {
             'github': ServiceConfig({'name': 'hub'}),
@@ -273,7 +274,8 @@ class TestEncryptedFileProjectKeychain(TestBaseProjectKeychain):
             'mrbelvedere':{'attributes':{'mr':{'required':True}}},
             'apextestsdb':{'attributes':{'apex':{'required':True}}},
         }
-        self.project_name = 'TestRepo'
+        self.project_config.config['name'] = 'TestProject'
+        self.project_name = 'TestProject'
         self.connected_app_config = ConnectedAppOAuthConfig({'test': 'value'})
         self.org_config = OrgConfig({'foo': 'bar'})
         self.services = {

--- a/cumulusci/core/tests/test_keychain.py
+++ b/cumulusci/core/tests/test_keychain.py
@@ -39,7 +39,7 @@ class TestBaseProjectKeychain(unittest.TestCase):
             'mrbelvedere':{'attributes':{'mr':{'required':True}}},
             'apextestsdb':{'attributes':{'apex':{'required':True}}},
         }
-        self.project_config.config['name'] = 'TestProject'
+        self.project_config.project__name = 'TestProject'
         self.connected_app_config = ConnectedAppOAuthConfig({'test': 'value'})
         self.services = {
             'github': ServiceConfig({'name': 'hub'}),
@@ -274,7 +274,7 @@ class TestEncryptedFileProjectKeychain(TestBaseProjectKeychain):
             'mrbelvedere':{'attributes':{'mr':{'required':True}}},
             'apextestsdb':{'attributes':{'apex':{'required':True}}},
         }
-        self.project_config.config['name'] = 'TestProject'
+        self.project_config.project__name = 'TestProject'
         self.project_name = 'TestProject'
         self.connected_app_config = ConnectedAppOAuthConfig({'test': 'value'})
         self.org_config = OrgConfig({'foo': 'bar'})


### PR DESCRIPTION
# Critical Changes

# Changes
`project_local_dir` (e.g., `~/.cumulusci/NPSP-Extension-Template/`, home of the encrypted keychain and local override config) now rely on the project name configured in cumulusci.yml instead of the existence of a git remote named origin.

# Issues Closed
Fixes #226 - unhandled exception if repo doesn't have a remote named "origin" 