### PR TITLE
Bug/scratch org username

### DIFF
--- a/cumulusci/core/config.py
+++ b/cumulusci/core/config.py
@@ -392,8 +392,9 @@ class OrgConfig(BaseConfig):
     def org_id(self):
         return self.id.split('/')[-2]
 
-    @property(doc="Username for this org connection")
+    @property
     def username(self):
+        """ Username for the org connection. """
         return self.userinfo__preferred_username
 
     def load_userinfo(self):

--- a/cumulusci/core/config.py
+++ b/cumulusci/core/config.py
@@ -392,6 +392,10 @@ class OrgConfig(BaseConfig):
     def org_id(self):
         return self.id.split('/')[-2]
 
+    @property
+    def username(self):
+        return self.userinfo__preferred_username 
+
     def load_userinfo(self):
         self._load_userinfo()
 

--- a/cumulusci/core/config.py
+++ b/cumulusci/core/config.py
@@ -392,9 +392,9 @@ class OrgConfig(BaseConfig):
     def org_id(self):
         return self.id.split('/')[-2]
 
-    @property
+    @property(doc="Username for this org connection")
     def username(self):
-        return self.userinfo__preferred_username 
+        return self.userinfo__preferred_username
 
     def load_userinfo(self):
         self._load_userinfo()

--- a/cumulusci/core/tasks.py
+++ b/cumulusci/core/tasks.py
@@ -65,6 +65,10 @@ class BaseTask(object):
         """ Log the beginning of the task execution """
         self.logger.info('Beginning task: %s', self.__class__.__name__)
         if self.org_config:
-            self.logger.info('As user:        %s', self.org_config.userinfo__preferred_username)
-            self.logger.info('On org:         %s', self.org_config.org_id)
+            self.logger.info(
+                '%15s %s',
+                'As user:',
+                self.org_config.username
+            )
+            self.logger.info('%15s %s', 'In org:', self.org_config.org_id)
         self.logger.info('')


### PR DESCRIPTION
# Critical Changes

# Changes
adds a public property to OrgConfig that prints the username. task logging now prints the config.username property, which exists in both OrgConfig and ScratchOrgConfig.

# Issues Closed
#232 - scratch org builds not logging username