### PR TITLE
Feature/return values

### DIFF
--- a/cumulusci/core/config.py
+++ b/cumulusci/core/config.py
@@ -392,8 +392,9 @@ class OrgConfig(BaseConfig):
     def org_id(self):
         return self.id.split('/')[-2]
 
-    @property(doc="Username for this org connection")
+    @property
     def username(self):
+        """ Username for the org connection. """
         return self.userinfo__preferred_username
 
     def load_userinfo(self):

--- a/cumulusci/core/config.py
+++ b/cumulusci/core/config.py
@@ -392,6 +392,10 @@ class OrgConfig(BaseConfig):
     def org_id(self):
         return self.id.split('/')[-2]
 
+    @property
+    def username(self):
+        return self.userinfo__preferred_username 
+
     def load_userinfo(self):
         self._load_userinfo()
 

--- a/cumulusci/core/config.py
+++ b/cumulusci/core/config.py
@@ -392,9 +392,9 @@ class OrgConfig(BaseConfig):
     def org_id(self):
         return self.id.split('/')[-2]
 
-    @property
+    @property(doc="Username for this org connection")
     def username(self):
-        return self.userinfo__preferred_username 
+        return self.userinfo__preferred_username
 
     def load_userinfo(self):
         self._load_userinfo()

--- a/cumulusci/core/flows.py
+++ b/cumulusci/core/flows.py
@@ -15,7 +15,9 @@ class BaseFlow(object):
         self.flow_config = flow_config
         self.org_config = org_config
         self.task_return_values = []
+        """ A collection of return_values dicts in task execution order """
         self.task_results = []
+        """ A collection of result objects in task execution order """
         self.tasks = []
         self._init_logger()
         self._init_flow()

--- a/cumulusci/core/flows.py
+++ b/cumulusci/core/flows.py
@@ -14,7 +14,8 @@ class BaseFlow(object):
         self.project_config = project_config
         self.flow_config = flow_config
         self.org_config = org_config
-        self.responses = []
+        self.task_return_values = []
+        self.task_results = []
         self.tasks = []
         self._init_logger()
         self._init_flow()
@@ -122,10 +123,10 @@ class BaseFlow(object):
             self.logger.info(line)
 
         try:
-            response = task()
+            task()
             self.logger.info('Task complete: %s', task_name)
-            self.responses.append(response)
-            return response
+            self.task_results.append(task.result)
+            self.task_return_values.append(task.return_values)
         except Exception as e:
             self.logger.error('Task failed: %s', task_name)
             if not flow_task_config['flow_config'].get('ignore_failure'):

--- a/cumulusci/core/flows.py
+++ b/cumulusci/core/flows.py
@@ -103,7 +103,7 @@ class BaseFlow(object):
                 value_parts = value[2:].split('.')
                 parent = self._find_task_by_name(value_parts[0])
                 for attr in value_parts[1:]:
-                    parent = getattr(parent, attr)
+                    parent = parent.return_values.get(attr)
                 task_config.config['options'][option] = parent
 
         task_class = import_class(task_config.class_path)

--- a/cumulusci/core/tasks.py
+++ b/cumulusci/core/tasks.py
@@ -23,7 +23,9 @@ class BaseTask(object):
         self.task_config = task_config
         self.org_config = org_config
         self.return_values = {}
+        """ a dict of return_values that can be used by task callers """
         self.result = None
+        """ a simple result object for introspection """
         if self.salesforce_task and not self.org_config:
             raise TaskRequiresSalesforceOrg('This task requires a Saleforce '
                                             'org_config but none was passed '

--- a/cumulusci/core/tasks.py
+++ b/cumulusci/core/tasks.py
@@ -22,7 +22,8 @@ class BaseTask(object):
         self.project_config = project_config
         self.task_config = task_config
         self.org_config = org_config
-        self.return_value = {}
+        self.return_values = {}
+        self.result = None
         if self.salesforce_task and not self.org_config:
             raise TaskRequiresSalesforceOrg('This task requires a Saleforce '
                                             'org_config but none was passed '
@@ -70,8 +71,8 @@ class BaseTask(object):
 
     def __call__(self):
         self._log_begin()
-        res = self._run_task()
-        return res
+        self.result = self._run_task()
+        return self.return_values
 
     def _run_task(self):
         """ Subclasses should override to provide their implementation """

--- a/cumulusci/core/tasks.py
+++ b/cumulusci/core/tasks.py
@@ -1,9 +1,20 @@
+""" Tasks are the basic unit of execution in CumulusCI.
+
+Subclass BaseTask or a descendant to define custom task logic
+"""
+
 import logging
 
 from cumulusci.core.exceptions import TaskRequiresSalesforceOrg
 from cumulusci.core.exceptions import TaskOptionsError
 
+
 class BaseTask(object):
+    """ BaseTask provides the core execution logic for a Task
+
+    Subclass BaseTask and provide a `_run_task()` method with your
+    code.
+    """
     task_options = {}
     salesforce_task = False  # Does this task require a salesforce org?
 
@@ -11,8 +22,11 @@ class BaseTask(object):
         self.project_config = project_config
         self.task_config = task_config
         self.org_config = org_config
+        self.return_value = {}
         if self.salesforce_task and not self.org_config:
-            raise TaskRequiresSalesforceOrg('This task requires a Saleforce org_config but none was passed to __init__')
+            raise TaskRequiresSalesforceOrg('This task requires a Saleforce '
+                                            'org_config but none was passed '
+                                            'to the Task constructor')
         self._init_logger()
         self._init_options(kwargs)
         self._validate_options()
@@ -34,29 +48,31 @@ class BaseTask(object):
     def _validate_options(self):
         missing_required = []
         for name, config in self.task_options.items():
-            if config.get('required') == True and name not in self.options:
+            if config.get('required') is True and name not in self.options:
                 missing_required.append(name)
 
         if missing_required:
             raise TaskOptionsError(
-                'This task requires the options ({}) and no values were provided'.format(
+                '{} requires the options ({}) '
+                'and no values were provided'.format(
+                    self.__class__.__name__,
                     ', '.join(missing_required)
                 )
             )
 
     def _update_credentials(self):
-        """ Subclasses should override to do any logic necessary to refresh credentials """
+        """ Override to do any logic  to refresh credentials """
         pass
 
     def _init_task(self):
-        """ A method that subclasses can override to implement dynamic logic for initializing the task """
+        """ Override to implement dynamic logic for initializing the task. """
         pass
 
     def __call__(self):
         self._log_begin()
         res = self._run_task()
         return res
-    
+
     def _run_task(self):
         """ Subclasses should override to provide their implementation """
         pass

--- a/cumulusci/core/tasks.py
+++ b/cumulusci/core/tasks.py
@@ -65,6 +65,10 @@ class BaseTask(object):
         """ Log the beginning of the task execution """
         self.logger.info('Beginning task: %s', self.__class__.__name__)
         if self.org_config:
-            self.logger.info('As user:        %s', self.org_config.userinfo__preferred_username)
-            self.logger.info('On org:         %s', self.org_config.org_id)
+            self.logger.info(
+                '%15s %s',
+                'As user:',
+                self.org_config.username
+            )
+            self.logger.info('%15s %s', 'In org:', self.org_config.org_id)
         self.logger.info('')

--- a/cumulusci/core/tests/test_flows.py
+++ b/cumulusci/core/tests/test_flows.py
@@ -76,7 +76,7 @@ class TestBaseFlow(unittest.TestCase):
         # run the flow
         flow()
         # the flow results for the second task should be 'name'
-        self.assertEquals('supername', flow.tasks[1].result)
+        self.assertEquals('supername', flow.task_results[1])
 
     def test_call_no_tasks(self):
         """ A flow with no tasks will have no responses. """
@@ -87,7 +87,7 @@ class TestBaseFlow(unittest.TestCase):
         flow = BaseFlow(self.project_config, flow_config, self.org_config)
         flow()
 
-        self.assertEqual([], flow.responses)
+        self.assertEqual([], flow.task_return_values)
         self.assertEqual([], flow.tasks)
 
     def test_call_one_task(self):
@@ -101,7 +101,7 @@ class TestBaseFlow(unittest.TestCase):
         flow = BaseFlow(self.project_config, flow_config, self.org_config)
         flow()
 
-        self.assertEqual([{'name': 'supername'}], flow.responses)
+        self.assertEqual([{'name': 'supername'}], flow.task_return_values)
         self.assertEqual(1, len(flow.tasks))
 
     def test_call_many_tasks(self):
@@ -116,7 +116,7 @@ class TestBaseFlow(unittest.TestCase):
         flow = BaseFlow(self.project_config, flow_config, self.org_config)
         flow()
 
-        self.assertEqual([{'name': 'supername'}, {'name': 'supername'}], flow.responses)
+        self.assertEqual([{'name': 'supername'}, {'name': 'supername'}], flow.task_return_values)
         self.assertEqual(2, len(flow.tasks))
 
     def test_call_task_not_found(self):

--- a/cumulusci/core/tests/test_flows.py
+++ b/cumulusci/core/tests/test_flows.py
@@ -15,7 +15,7 @@ from cumulusci.core.config import OrgConfig
 class _TaskReturnsStuff(BaseTask):
 
     def _run_task(self):
-        self.name = 'supername'
+        self.return_values = {'name': 'supername'}
 
 
 class _TaskResponseName(BaseTask):
@@ -76,7 +76,7 @@ class TestBaseFlow(unittest.TestCase):
         # run the flow
         flow()
         # the flow results for the second task should be 'name'
-        self.assertEquals('supername', flow.responses[1])
+        self.assertEquals('supername', flow.tasks[1].result)
 
     def test_call_no_tasks(self):
         """ A flow with no tasks will have no responses. """
@@ -101,7 +101,7 @@ class TestBaseFlow(unittest.TestCase):
         flow = BaseFlow(self.project_config, flow_config, self.org_config)
         flow()
 
-        self.assertEqual([None], flow.responses)
+        self.assertEqual([{'name': 'supername'}], flow.responses)
         self.assertEqual(1, len(flow.tasks))
 
     def test_call_many_tasks(self):
@@ -116,7 +116,7 @@ class TestBaseFlow(unittest.TestCase):
         flow = BaseFlow(self.project_config, flow_config, self.org_config)
         flow()
 
-        self.assertEqual([None, None], flow.responses)
+        self.assertEqual([{'name': 'supername'}, {'name': 'supername'}], flow.responses)
         self.assertEqual(2, len(flow.tasks))
 
     def test_call_task_not_found(self):

--- a/cumulusci/core/tests/test_tasks.py
+++ b/cumulusci/core/tests/test_tasks.py
@@ -1,0 +1,70 @@
+""" Tests for the CumulusCI task module """
+
+import unittest
+
+import collections
+
+from cumulusci.core.tasks import BaseTask
+from cumulusci.core.config import BaseGlobalConfig
+from cumulusci.core.config import BaseProjectConfig
+from cumulusci.core.config import TaskConfig
+from cumulusci.core.config import OrgConfig
+
+
+class TestBaseTaskCallable(unittest.TestCase):
+    """ Tests for the BaseTask callable interface.
+
+    BaseTask is Callable.
+    Calling a BaseTask returns the return_values.
+    Task results are available.
+    """
+
+    task_class = BaseTask
+
+    def setUp(self):
+        self.global_config = BaseGlobalConfig()
+        self.project_config = BaseProjectConfig(self.global_config)
+        self.org_config = OrgConfig({'foo': 'bar'})
+        self.task_config = TaskConfig()
+
+    def test_task_is_callable(self):
+        """ BaseTask is Callable """
+        task = self.__class__.task_class(
+            self.project_config,
+            self.task_config,
+            self.org_config
+        )
+
+        self.assertIsInstance(task, collections.Callable)
+
+    def test_get_return_values(self):
+        """ Callable interface returns retvals """
+
+        class _TaskReturnsStuff(BaseTask):
+            def _run_task(self):
+                self.return_values['name'] = 'return!'
+
+        task = _TaskReturnsStuff(
+            self.project_config,
+            self.task_config,
+            self.org_config
+        )
+        return_values = task()
+
+        self.assertIn('name', return_values)
+
+    def test_get_task_result(self):
+        """ Task results available as an instance member """
+
+        class _TaskHasResult(BaseTask):
+            def _run_task(self):
+                return -1
+
+        task = _TaskHasResult(
+            self.project_config,
+            self.task_config,
+            self.org_config
+        )
+        task()
+
+        self.assertEqual(task.result, -1)

--- a/cumulusci/tasks/github.py
+++ b/cumulusci/tasks/github.py
@@ -140,7 +140,7 @@ class CreateRelease(BaseGithubTask):
             name = version,
             prerelease = prerelease,
         )
-
+        self.return_values = {'tag_name': self.tag_name}
         self.logger.info('Created release {} at {}'.format(release.name, release.html_url))
 
 class MergeBranch(BaseGithubTask):

--- a/cumulusci/tasks/salesforce.py
+++ b/cumulusci/tasks/salesforce.py
@@ -1015,10 +1015,13 @@ class PackageUpload(BaseSalesforceToolingApiTask):
             if version['ReleaseState'] == 'Beta':
                 self.version_number += ' (Beta {})'.format(version['BuildNumber'])
 
+            self.return_values = {'version_number': self.version_number}
+
             self.logger.info('Uploaded package version {} with Id {}'.format(
                 self.version_number,
                 version_id
             ))
+
 
 
 class RunApexTests(BaseSalesforceToolingApiTask):

--- a/cumulusci/tasks/util.py
+++ b/cumulusci/tasks/util.py
@@ -41,6 +41,6 @@ class Sleep(BaseTask):
     
     def _run_task(self):
         self.logger.info("Sleeping for {} seconds".format(self.options['seconds']))
-        time.sleep(self.options['seconds'])
+        time.sleep(float(self.options['seconds']))
         self.logger.info("Done")
 


### PR DESCRIPTION
# Critical Changes
Flows no longer have access to task instance attributes for subsequent task options. Instead, custom task classes should set their task return_values member.

# Changes
- add some basic unit tests to tasks
- pep8 and pylint tasks
- differentiate BaseTask.return_values and BaseTask.result
- differentiate BaseFlow.task_return_values and BaseFlow.task_results
- add return_values to PackageUpload and CreateTag

# Issues Closed
#233 - Formal task return values