### PR TITLE
Feature/task context in flow

### DIFF
--- a/cumulusci/core/flows.py
+++ b/cumulusci/core/flows.py
@@ -19,6 +19,7 @@ class BaseFlow(object):
         self.task_results = []
         """ A collection of result objects in task execution order """
         self.tasks = []
+        """ A collection of configured task objects, either run or failed """
         self._init_logger()
         self._init_flow()
 

--- a/cumulusci/core/flows.py
+++ b/cumulusci/core/flows.py
@@ -72,6 +72,10 @@ class BaseFlow(object):
                 task_info['task_config'].description,
             ))
 
+        config.append('Organization:')
+        config.append('  {}: {}'.format('Username', self.org_config.username))
+        config.append('  {}: {}'.format('  Org Id', self.org_config.org_id))
+
         return config
 
     def __call__(self):
@@ -119,6 +123,7 @@ class BaseFlow(object):
             self.project_config,
             task_config,
             org_config=self.org_config,
+            flow=self
         )
         self.tasks.append(task)
 

--- a/cumulusci/core/flows.py
+++ b/cumulusci/core/flows.py
@@ -72,9 +72,10 @@ class BaseFlow(object):
                 task_info['task_config'].description,
             ))
 
-        config.append('Organization:')
-        config.append('  {}: {}'.format('Username', self.org_config.username))
-        config.append('  {}: {}'.format('  Org Id', self.org_config.org_id))
+        if self.org_config is not None:
+            config.append('Organization:')
+            config.append('  {}: {}'.format('Username', self.org_config.username))
+            config.append('  {}: {}'.format('  Org Id', self.org_config.org_id))
 
         return config
 

--- a/cumulusci/core/tasks.py
+++ b/cumulusci/core/tasks.py
@@ -18,7 +18,8 @@ class BaseTask(object):
     task_options = {}
     salesforce_task = False  # Does this task require a salesforce org?
 
-    def __init__(self, project_config, task_config, org_config=None, flow=None, **kwargs):
+    def __init__(self, project_config, task_config,
+                 org_config=None, flow=None, **kwargs):
         self.project_config = project_config
         self.task_config = task_config
         self.org_config = org_config

--- a/cumulusci/core/tasks.py
+++ b/cumulusci/core/tasks.py
@@ -83,7 +83,7 @@ class BaseTask(object):
     def _log_begin(self):
         """ Log the beginning of the task execution """
         self.logger.info('Beginning task: %s', self.__class__.__name__)
-        if self.org_config:
+        if self.salesforce_task:
             self.logger.info(
                 '%15s %s',
                 'As user:',

--- a/cumulusci/core/tasks.py
+++ b/cumulusci/core/tasks.py
@@ -18,14 +18,16 @@ class BaseTask(object):
     task_options = {}
     salesforce_task = False  # Does this task require a salesforce org?
 
-    def __init__(self, project_config, task_config, org_config=None, **kwargs):
+    def __init__(self, project_config, task_config, org_config=None, flow=None, **kwargs):
         self.project_config = project_config
         self.task_config = task_config
         self.org_config = org_config
         self.return_values = {}
         """ a dict of return_values that can be used by task callers """
         self.result = None
-        """ a simple result object for introspection """
+        """ a simple result object for introspection, often a return_code """
+        self.flow = flow
+        """ The flow for this task execution """
         if self.salesforce_task and not self.org_config:
             raise TaskRequiresSalesforceOrg('This task requires a Saleforce '
                                             'org_config but none was passed '
@@ -83,11 +85,7 @@ class BaseTask(object):
     def _log_begin(self):
         """ Log the beginning of the task execution """
         self.logger.info('Beginning task: %s', self.__class__.__name__)
-        if self.salesforce_task:
-            self.logger.info(
-                '%15s %s',
-                'As user:',
-                self.org_config.username
-            )
+        if self.salesforce_task and not self.flow:
+            self.logger.info('%15s %s', 'As user:', self.org_config.username)
             self.logger.info('%15s %s', 'In org:', self.org_config.org_id)
         self.logger.info('')

--- a/cumulusci/core/tests/test_flows.py
+++ b/cumulusci/core/tests/test_flows.py
@@ -11,7 +11,7 @@ from cumulusci.core.config import BaseGlobalConfig
 from cumulusci.core.config import BaseProjectConfig
 from cumulusci.core.config import FlowConfig
 from cumulusci.core.config import OrgConfig
-from cumulusci.core.utils import MockLoggingHandler
+from cumulusci.core.tests.utils import MockLoggingHandler
 import cumulusci.core
 
 ORG_ID = "00D000000000001"
@@ -189,6 +189,23 @@ class TestBaseFlow(unittest.TestCase):
         org_id_logs = [s for s in self.flow_log['info'] if ORG_ID in s]
 
         self.assertEqual(1, len(org_id_logs))
+
+    def test_flow_no_org_no_org_id(self):
+        """ A flow without an org does not print the org ID """
+
+        flow_config = FlowConfig({
+            'description': 'Run two tasks',
+            'tasks': {
+                1: {'task': 'pass_name'},
+                2: {'task': 'pass_name'},
+            }
+        })
+        flow = BaseFlow(self.project_config, flow_config, None)
+        flow()
+
+        self.assertFalse(any(
+            ORG_ID in s for s in self.flow_log['info']
+        ))
 
     def test_flow_prints_org_id_once_only(self):
         """ A flow with sf tasks prints the org ID only once."""

--- a/cumulusci/core/tests/test_flows.py
+++ b/cumulusci/core/tests/test_flows.py
@@ -115,6 +115,10 @@ class TestBaseFlow(unittest.TestCase):
         flow = BaseFlow(self.project_config, flow_config, self.org_config)
         flow()
 
+        self.assertTrue(any(
+            "Flow Description: Run one task" in s for s in self.flow_log['info']
+        ))
+
         self.assertEqual([{'name': 'supername'}], flow.task_return_values)
         self.assertEqual(1, len(flow.tasks))
 

--- a/cumulusci/core/tests/test_tasks.py
+++ b/cumulusci/core/tests/test_tasks.py
@@ -28,6 +28,14 @@ class TestBaseTaskCallable(unittest.TestCase):
 
     task_class = BaseTask
 
+    @classmethod
+    def setUpClass(cls):
+        super(TestBaseTaskCallable, cls).setUpClass()
+        logger = logging.getLogger(cumulusci.core.tasks.__name__)
+        logger.setLevel(logging.DEBUG)
+        cls._task_log_handler = MockLoggingHandler(logging.DEBUG)
+        logger.addHandler(cls._task_log_handler)
+
     def setUp(self):
         self.global_config = BaseGlobalConfig()
         self.project_config = BaseProjectConfig(self.global_config)
@@ -36,6 +44,8 @@ class TestBaseTaskCallable(unittest.TestCase):
             'org_id': '00D000000000001'
         })
         self.task_config = TaskConfig()
+        self._task_log_handler.reset()
+        self.task_messages = self._task_log_handler.messages
 
     def test_task_is_callable(self):
         """ BaseTask is Callable """
@@ -83,16 +93,12 @@ class TestBaseTaskCallable(unittest.TestCase):
             self.task_config,
             self.org_config
         )
-        mock_logger = MockLoggingHandler(logging.DEBUG)
-        logger = logging.getLogger(cumulusci.core.tasks.__name__)
-        logger.setLevel(logging.DEBUG)
-        logger.addHandler(mock_logger)
 
         task()
 
         task_name_logs = [log for
                           log in
-                          mock_logger.messages['info'] if
+                          self.task_messages['info'] if
                           '_TaskHasResult' in log]
 
         self.assertEquals(1, len(task_name_logs))

--- a/cumulusci/core/tests/test_tasks.py
+++ b/cumulusci/core/tests/test_tasks.py
@@ -11,9 +11,11 @@ from cumulusci.core.config import BaseProjectConfig
 from cumulusci.core.config import TaskConfig
 from cumulusci.core.config import OrgConfig
 from cumulusci.core.config import FlowConfig
-from cumulusci.core.utils import MockLoggingHandler
+from cumulusci.core.tests.utils import MockLoggingHandler
 import cumulusci.core
 
+ORG_ID = '00D000000000001'
+USERNAME = 'sample@example'
 
 class _TaskHasResult(BaseTask):
     def _run_task(self):
@@ -49,8 +51,8 @@ class TestBaseTaskCallable(unittest.TestCase):
         self.global_config = BaseGlobalConfig()
         self.project_config = BaseProjectConfig(self.global_config)
         self.org_config = OrgConfig({
-            'username': 'sample@example',
-            'org_id': '00D000000000001'
+            'username': USERNAME,
+            'org_id': ORG_ID
         })
         self.task_config = TaskConfig()
         self._task_log_handler.reset()
@@ -94,7 +96,7 @@ class TestBaseTaskCallable(unittest.TestCase):
 
         self.assertEqual(task.result, -1)
 
-    def test_task_logs_name(self):
+    def test_task_logs_name_not_org(self):
         """ A task logs the task class name to info (and not creds) """
 
         task = _TaskHasResult(
@@ -108,6 +110,10 @@ class TestBaseTaskCallable(unittest.TestCase):
             "_TaskHasResult" in s for s in self.task_log['info']
         ))
 
+        self.assertFalse(any(
+            ORG_ID in s for s in self.task_log['info']
+        ))
+
     def test_salesforce_task_logs_org_id(self):
         """ A salesforce_task will also log the org id & username """
 
@@ -119,7 +125,7 @@ class TestBaseTaskCallable(unittest.TestCase):
         task()
 
         self.assertTrue(any(
-            "00D000000000001" in s for s in self.task_log['info']
+            ORG_ID in s for s in self.task_log['info']
         ))
 
     def test_no_id_if_run_from_flow(self):
@@ -133,5 +139,5 @@ class TestBaseTaskCallable(unittest.TestCase):
         )
         task()
         self.assertFalse(any(
-            "00D000000000001" in s for s in self.task_log['info']
+            ORG_ID in s for s in self.task_log['info']
         ))

--- a/cumulusci/core/tests/test_tasks.py
+++ b/cumulusci/core/tests/test_tasks.py
@@ -5,10 +5,12 @@ import logging
 import collections
 
 from cumulusci.core.tasks import BaseTask
+from cumulusci.core.flows import BaseFlow
 from cumulusci.core.config import BaseGlobalConfig
 from cumulusci.core.config import BaseProjectConfig
 from cumulusci.core.config import TaskConfig
 from cumulusci.core.config import OrgConfig
+from cumulusci.core.config import FlowConfig
 from cumulusci.core.utils import MockLoggingHandler
 import cumulusci.core
 
@@ -117,5 +119,19 @@ class TestBaseTaskCallable(unittest.TestCase):
         task()
 
         self.assertTrue(any(
+            "00D000000000001" in s for s in self.task_log['info']
+        ))
+
+    def test_no_id_if_run_from_flow(self):
+        """ A salesforce_task will not log the org id if run from a flow """
+
+        task = _SfdcTask(
+            self.project_config,
+            self.task_config,
+            self.org_config,
+            flow=BaseFlow(self.project_config, FlowConfig(), self.org_config)
+        )
+        task()
+        self.assertFalse(any(
             "00D000000000001" in s for s in self.task_log['info']
         ))

--- a/cumulusci/core/tests/utils.py
+++ b/cumulusci/core/tests/utils.py
@@ -1,0 +1,35 @@
+""" Utilities for testing CumulusCI
+
+MockLoggingHandler: a logging handler that we can assert"""
+
+import logging
+
+
+class MockLoggingHandler(logging.Handler):
+    """Mock logging handler to check for expected logs.
+
+    Messages are available from an instance's ``messages`` dict, in order,
+    indexed by a lowercase log level string (e.g., 'debug', 'info', etc.).
+    """
+
+    def __init__(self, *args, **kwargs):
+        self.messages = {'debug': [], 'info': [], 'warning': [], 'error': [],
+                         'critical': []}
+        super(MockLoggingHandler, self).__init__(*args, **kwargs)
+
+    def emit(self, record):
+        "Store a message from ``record`` in the instance's ``messages`` dict."
+        self.acquire()
+        try:
+            self.messages[record.levelname.lower()].append(record.getMessage())
+        finally:
+            self.release()
+
+    def reset(self):
+        """ Reset the handler in TestCase.setUp() to clear the msg list """
+        self.acquire()
+        try:
+            for message_list in self.messages.values():
+                del message_list[:]
+        finally:
+            self.release()

--- a/cumulusci/core/utils.py
+++ b/cumulusci/core/utils.py
@@ -1,6 +1,36 @@
+""" Utilities for CumulusCI Core
+
+import_class: Task class defn import helper
+MockLoggingHandler: a handler for testing logging """
+
+import logging
+
+
 def import_class(path):
+    """ Import a class from a string module class path """
     components = path.split('.')
     module = components[:-1]
     module = '.'.join(module)
     mod = __import__(module, fromlist=[components[-1]])
     return getattr(mod, components[-1])
+
+
+class MockLoggingHandler(logging.Handler):
+    """Mock logging handler to check for expected logs."""
+
+    def __init__(self, *args, **kwargs):
+        self.reset()
+        logging.Handler.__init__(self, *args, **kwargs)
+
+    def emit(self, record):
+        self.messages[record.levelname.lower()].append(record.getMessage())
+
+    def reset(self):
+        """ Reset the handler for each test """
+        self.messages = {
+            'debug': [],
+            'info': [],
+            'warning': [],
+            'error': [],
+            'critical': [],
+        }

--- a/cumulusci/core/utils.py
+++ b/cumulusci/core/utils.py
@@ -1,7 +1,6 @@
 """ Utilities for CumulusCI Core
 
-import_class: Task class defn import helper
-MockLoggingHandler: a handler for testing logging """
+import_class: Task class defn import helper """
 
 import logging
 
@@ -13,33 +12,3 @@ def import_class(path):
     module = '.'.join(module)
     mod = __import__(module, fromlist=[components[-1]])
     return getattr(mod, components[-1])
-
-
-class MockLoggingHandler(logging.Handler):
-    """Mock logging handler to check for expected logs.
-
-    Messages are available from an instance's ``messages`` dict, in order, indexed by
-    a lowercase log level string (e.g., 'debug', 'info', etc.).
-    """
-
-    def __init__(self, *args, **kwargs):
-        self.messages = {'debug': [], 'info': [], 'warning': [], 'error': [],
-                         'critical': []}
-        super(MockLoggingHandler, self).__init__(*args, **kwargs)
-
-    def emit(self, record):
-        "Store a message from ``record`` in the instance's ``messages`` dict."
-        self.acquire()
-        try:
-            self.messages[record.levelname.lower()].append(record.getMessage())
-        finally:
-            self.release()
-
-    def reset(self):
-        """ Reset the handler in TestCase.setUp() to clear the msg list """
-        self.acquire()
-        try:
-            for message_list in self.messages.values():
-                del message_list[:]
-        finally:
-            self.release()


### PR DESCRIPTION
# Critical Changes

# Changes
- Tasks that are not salesforce tasks will no longer log the org_config details even if an org_config was passed.
- The flow engine will print the org_config details at the top of a flow.
- When being run by the flow engine, tasks will not individually print their org_config details. This means, the org id and username are only printed once in the flow log. Yay!
- BaseTask has a new optional "flow" attribute which will be set to the BaseFlow instance when the task is executed from the flow runner. 

# Issues Closed
