### PR TITLE
Fixes #267, skip RecordType when generating package.xml for deletion

### DIFF
--- a/cumulusci/tasks/salesforce.py
+++ b/cumulusci/tasks/salesforce.py
@@ -668,7 +668,7 @@ class UninstallPackaged(UninstallLocal):
 
 class UninstallPackagedIncremental(UninstallPackaged):
     name = 'UninstallPackagedIncremental'
-    skip_types = ['Scontrol']
+    skip_types = ['RecordType','Scontrol']
     task_options = {
         'path': {
             'description': 'The local path to compare to the retrieved packaged metadata from the org.  Defaults to src',


### PR DESCRIPTION
# Critical Changes

# Changes
* Skips RecordType metadata when constructing a package.xml for deletion (i.e. destructiveChanges.xml)

# Issues Closed
