### PR TITLE
Pushes will now only be monitored if no start time is given.

### DIFF
--- a/cumulusci/tasks/push/tasks.py
+++ b/cumulusci/tasks/push/tasks.py
@@ -230,7 +230,8 @@ class SchedulePushOrgList(BaseSalesforcePushTask):
         self.logger.info('Push Request {} is queued for execution.'.format(self.request_id))
 
         # Report the status
-        self._report_push_status(self.request_id)
+        if not start_time:
+            self._report_push_status(self.request_id)
 
 class SchedulePushOrgQuery(SchedulePushOrgList):
     task_options = {


### PR DESCRIPTION
# Changes
If no start time is given to the SchedulePushOrgList-based tasks, the push upgrade will not be automatically monitored.