### PR TITLE
Push enhancements

### DIFF
--- a/cumulusci/tasks/push/push_api.py
+++ b/cumulusci/tasks/push/push_api.py
@@ -545,7 +545,7 @@ class SalesforcePushApi(object):
                 scheduled_orgs,
             )
         )
-        return request_id
+        return request_id, scheduled_orgs
 
     def _add_batch(self, batch, request_id):
 
@@ -602,6 +602,12 @@ class SalesforcePushApi(object):
         for record in records:
             if record['attributes']['referenceId'] == ref_id:
                 return record['SubscriberOrganizationKey']
+
+    def cancel_push_request(self, request_id):
+        return self.sf.PackagePushRequest.update(
+            request_id,
+            {'Status': 'Canceled'},
+        )
 
     def run_push_request(self, request_id):
         # Set the request to Pending status

--- a/cumulusci/tasks/push/push_api.py
+++ b/cumulusci/tasks/push/push_api.py
@@ -571,8 +571,12 @@ class SalesforcePushApi(object):
             )
         except SalesforceMalformedRequest as e:
             invalid_orgs = set()
+            retry_all = False
             for result in e.content['results']:
                 for error in result['errors']:
+                    if 'Something bad has happened' in error['message']:
+                        retry_all = True
+                        break
                     if error['statusCode'] in [
                                 'DUPLICATE_VALUE',
                                 'INVALID_OPERATION',
@@ -589,13 +593,18 @@ class SalesforcePushApi(object):
                         ))
                     else:
                         raise
-            # remove invalid orgs and retry
-            batch -= invalid_orgs
-            if batch:
-                self.logger.warn('Retrying batch without invalid orgs')
+                if retry_all:
+                    break
+            if retry_all:
+                self.logger.warn('Retrying batch')
                 batch = self._add_batch(batch, request_id)
             else:
-                self.logger.error('Skipping batch (no valid orgs)')
+                batch -= invalid_orgs
+                if batch:
+                    self.logger.warn('Retrying batch without invalid orgs')
+                    batch = self._add_batch(batch, request_id)
+                else:
+                    self.logger.error('Skipping batch (no valid orgs)')
         return batch
 
     def _get_org_id(self, records, ref_id):

--- a/cumulusci/tasks/push/tasks.py
+++ b/cumulusci/tasks/push/tasks.py
@@ -97,6 +97,8 @@ class BaseSalesforcePushTask(BaseSalesforceApiTask):
         orgs = []
         with open(path, 'r') as f:
             for line in f:
+                if line.isspace():
+                    continue
                 org = line.split()[0]
                 if org:
                     orgs.append(org)

--- a/cumulusci/tasks/push/tasks.py
+++ b/cumulusci/tasks/push/tasks.py
@@ -99,9 +99,7 @@ class BaseSalesforcePushTask(BaseSalesforceApiTask):
             for line in f:
                 if line.isspace():
                     continue
-                org = line.split()[0]
-                if org:
-                    orgs.append(org)
+                orgs.append(line.split()[0])
         return orgs
 
     def _report_push_status(self, request_id):

--- a/cumulusci/tasks/push/tasks.py
+++ b/cumulusci/tasks/push/tasks.py
@@ -95,9 +95,11 @@ class BaseSalesforcePushTask(BaseSalesforceApiTask):
 
     def _load_orgs_file(self, path):
         orgs = []
-        with open(path, 'r') as f_orgs:
-            for org in f_orgs:
-                orgs.append(org.strip())
+        with open(path, 'r') as f:
+            for line in f:
+                org = line.split()[0]
+                if org:
+                    orgs.append(org)
         return orgs
 
     def _report_push_status(self, request_id):


### PR DESCRIPTION
# Critical Changes

# Changes
* Push org lists (text files with one org ID per line) can now have comments and blank lines. The first word on the line is assumed to be the org ID and anything after that is ignored.

# Issues Closed
Fixes #294 
Fixes #306 
Fixes #308 