### PR TITLE
Feature/apexlogging WIP

### DIFF
--- a/cumulusci/tasks/anonymous_apex.py
+++ b/cumulusci/tasks/anonymous_apex.py
@@ -12,18 +12,34 @@ class AnonymousApexTask(BaseSalesforceApiTask):
         'apex': {
             'description': 'The apex to run.',
             'required': True,
-        }
+        },
+        'profiling': {'description': 'The ApexProfiling log level'},
+        'apexcode': {'description': 'The ApexCode log level'},
+        'callout': {'description': 'The Callout log level'},
+        'database': {'description': 'The database log level'},
+        'system': {'description': 'The System log level'},
+        'validation': {'description': 'The Validation log level'},
+        'visualforce': {'description': 'The Visualforce log level'},
+        'workflow': {'description': 'The Workflow log level'},
     }
 
     def _run_task(self):
         self.logger.info('Executing Anonymous Apex')
-        with ApexLogger(self) as apex_logs:
+        with ApexLogger(self,
+                        profiling=self.options.get('profiling', None),
+                        apex=self.options.get('apexcode', None),
+                        callout=self.options.get('callout', None),
+                        database=self.options.get('database', None),
+                        system=self.options.get('system', None),
+                        validation=self.options.get('validation', None),
+                        visualforce=self.options.get('visualforce', None),
+                        workflow=self.options.get('workflow', None),) as apex_logs:
             result = self.tooling._call_salesforce(
                 method='GET',
                 url='{}executeAnonymous'.format(self.tooling.base_url),
                 params={'anonymousBody': self.options['apex']},
             )
-        pprint.pprint(apex_logs.logs)
+
         if result.status_code != 200:
             raise SalesforceException(
                 result.status_code,
@@ -41,3 +57,6 @@ class AnonymousApexTask(BaseSalesforceApiTask):
                 anon_results['exceptionMessage'], anon_results['exceptionStackTrace'])
 
         self.logger.info('Anonymous Apex Success')
+
+        for log_id in apex_logs.logs:
+            self.logger.info(apex_logs.logs[log_id])

--- a/cumulusci/tasks/anonymous_apex.py
+++ b/cumulusci/tasks/anonymous_apex.py
@@ -1,10 +1,10 @@
-from cumulusci.tasks.salesforce import BaseSalesforceToolingApiTask
+from cumulusci.tasks.salesforce import BaseSalesforceApiTask
 from cumulusci.core.exceptions import ApexCompilationException
 from cumulusci.core.exceptions import ApexException
 from cumulusci.core.exceptions import SalesforceException
 
 
-class AnonymousApexTask(BaseSalesforceToolingApiTask):
+class AnonymousApexTask(BaseSalesforceApiTask):
     """ Executes a string of anonymous apex. """
     task_options = {
         'apex': {

--- a/cumulusci/tasks/anonymous_apex.py
+++ b/cumulusci/tasks/anonymous_apex.py
@@ -7,7 +7,10 @@ import pprint
 
 
 class AnonymousApexTask(BaseSalesforceApiTask):
-    """ Executes a string of anonymous apex. """
+    """ Executes a string of anonymous apex. 
+    
+    cci task run execute_anon -o apex 'System.debug(1);' -o system finest does what you think it should
+    """
     task_options = {
         'apex': {
             'description': 'The apex to run.',

--- a/cumulusci/tasks/apex_logging.py
+++ b/cumulusci/tasks/apex_logging.py
@@ -21,6 +21,8 @@ class ApexLogger(object):
         results = l.get_logs()
 
     dostuffwith(results)
+
+    HUGE TODO: parse the logs
     """
 
     def __init__(self, task, **kwargs):

--- a/cumulusci/tasks/apex_logging.py
+++ b/cumulusci/tasks/apex_logging.py
@@ -1,0 +1,152 @@
+
+import datetime
+
+
+def decode_to_unicode(content):
+    if content:
+        try:
+            # Try to decode ISO-8859-1 to unicode
+            return content.decode('ISO-8859-1')
+        except UnicodeEncodeError:
+            # Assume content is unicode already
+            return content
+
+
+class ApexLogger(object):
+    """ Apex logging services as a context manager:
+
+    example usage:
+    with ApexLogger(self.tooling, profiling='DEBUG') as l:
+        self._run_task()
+        results = l.get_logs()
+
+    dostuffwith(results)
+    """
+
+    def __init__(self, task, **kwargs):
+        # type: (BaseSalesforceApiTask, **str) -> None
+        # from BaseSalesforceApiTask we use the:
+        #   * logger
+        #   * tooling.query
+        #   * get_tooling_object
+        self.task = task
+        self.user_id = self.task.org_config.user_id
+        self.debug_level_id = None
+        self.trace_flag_id = None
+        self.most_recent_log_id = None
+        self.logger = self.task.logger
+        self.logs = {}
+
+        if kwargs is None:
+            kwargs = {}
+
+        self.debug_level = {
+            'ApexCode': kwargs.get('apex', 'Info'),
+            'ApexProfiling': kwargs.get('profiling', 'Debug'),
+            'Callout': kwargs.get('callout', 'Info'),
+            'Database': kwargs.get('database', 'Info'),
+            'DeveloperName': kwargs.get('developer_name', 'CumulusCI'),
+            'MasterLabel': kwargs.get('label', 'CumulusCI'),
+            'System': kwargs.get('system', 'Info'),
+            'Validation': kwargs.get('validation', 'Info'),
+            'Visualforce': kwargs.get('visualforce', 'Info'),
+            'Workflow': kwargs.get('workflow', 'Info'),
+        }
+
+
+    def __enter__(self):
+        self._delete_debug_level()
+        self._remove_trace_flags()
+        self._create_debug_level()
+        self._create_trace_flag()
+        self._get_most_recent_log()
+
+        return self
+
+    def __exit__(self, *args):
+        # we don't care if the context had an exception
+        # and we do not return, so the runtime handles it up stack
+        self.logs = self._get_logs_since()
+        self._delete_debug_level()
+        self.most_recent_log_id = None
+
+    def _create_debug_level(self):
+        self.logger.info('Creating DebugLevel object')
+        DebugLevel = self.task.get_tooling_object('DebugLevel')
+        result = DebugLevel.create(self.debug_level)
+        self.debug_level_id = result['id']
+
+    def _create_trace_flag(self):
+        self.logger.info('Setting up trace flag to capture debug logs')
+        # New TraceFlag expires 12 hours from now
+        expiration_date = (datetime.datetime.utcnow() +
+                           datetime.timedelta(seconds=60 * 60 * 12))
+        TraceFlag = self.task.get_tooling_object('TraceFlag')
+        result = TraceFlag.create({
+            'DebugLevelId': self.debug_level_id,
+            'ExpirationDate': expiration_date.isoformat(),
+            'LogType': 'USER_DEBUG',
+            'TracedEntityId': self.user_id,
+        })
+        self.trace_flag_id = result['id']
+        self.logger.info('Created TraceFlag for user')
+
+    def _delete_debug_level(self):
+        """ Remove all debug levels from the org """
+        # TODO: be more selective?
+        self.logger.info('Deleting existing DebugLevel objects')
+        result = self.task.tooling.query('Select Id from DebugLevel')
+        if result['totalSize']:
+            DebugLevel = self.task.get_tooling_object('DebugLevel')
+            for record in result['records']:
+                DebugLevel.delete(str(record['Id']))
+
+    def _get_most_recent_log(self):
+        """ retrieve the ID of the most recent log for the running user """
+
+        result = self.task.tooling.query(
+            "SELECT Id FROM ApexLog WHERE LogUserId = '{}' "
+            "ORDER BY SystemModstamp DESC LIMIT 1".format(
+                self.user_id
+            )
+        )
+        if result['totalSize']:
+            self.most_recent_log_id = result['records'][0]['Id']
+
+    def _get_logs_since(self):
+        """ Get the logs since the context manager was entered """
+
+        extra_where = ''
+        if self.most_recent_log_id:
+            extra_where = 'AND Id > \'{}\''.format(self.most_recent_log_id)
+
+        result = self.task.tooling.query_all(
+            'SELECT Id, Application, DurationMilliseconds, Location, '
+            'LogLength, LogUserId, Operation, Request, StartTime, Status '
+            'FROM ApexLog WHERE LogUserId = \'{}\' {}'.format(
+                self.user_id, extra_where)
+        )
+
+        logs = {}
+        for log in result['records']:
+            body_url = '{}sobjects/ApexLog/{}/Body'.format(
+                self.task.tooling.base_url, log['Id'])
+            response = self.task.tooling.request.get(body_url,
+                                                     headers=self.task.tooling.headers)
+            logs[log['Id']] = decode_to_unicode(response.content)
+
+        return logs
+
+    def _remove_trace_flags(self):
+        """ Remove all existing traceflags for the running user. """
+
+        self.logger.info('Deleting existing TraceFlag objects')
+        result = self.task.tooling.query(
+            "Select Id from TraceFlag Where TracedEntityId = '{}'".format(
+                self.user_id
+            )
+        )
+        if result['totalSize']:
+            TraceFlag = self.task.get_tooling_object('TraceFlag')
+            for record in result['records']:
+                TraceFlag.delete(str(record['Id']))

--- a/cumulusci/tasks/salesforce.py
+++ b/cumulusci/tasks/salesforce.py
@@ -70,6 +70,10 @@ class BaseSalesforceApiTask(BaseSalesforceTask):
 
     def _init_task(self):
         self.sf = self._init_api()
+        self.tooling = self._init_api()
+        self.tooling.base_url += 'tooling/'
+        self._init_class()
+
 
     def _init_api(self):
         if self.api_version:
@@ -83,16 +87,9 @@ class BaseSalesforceApiTask(BaseSalesforceTask):
             version=api_version,
         )
 
-
-class BaseSalesforceToolingApiTask(BaseSalesforceApiTask):
-    name = 'BaseSalesforceToolingApiTask'
-
-    def _init_task(self):
-        self.tooling = self._init_api()
-        self.tooling.base_url += 'tooling/'
-        self._init_class()
-
     def _init_class(self):
+        """  used by the apextests tasks to init instance vars """
+        #TODO: understand why
         pass
 
     def _get_tooling_object(self, obj_name):
@@ -951,7 +948,7 @@ class UpdateAdminProfile(Deploy):
         return api()
 
 
-class PackageUpload(BaseSalesforceToolingApiTask):
+class PackageUpload(BaseSalesforceApiTask):
     name = 'PackageUpload'
     api_version = '38.0'
     task_options = {
@@ -1070,7 +1067,7 @@ class PackageUpload(BaseSalesforceToolingApiTask):
 
 
 
-class RunApexTests(BaseSalesforceToolingApiTask):
+class RunApexTests(BaseSalesforceApiTask):
     task_options = {
         'test_name_match': {
             'description': ('Query to find Apex test classes to run ' +

--- a/cumulusci/tasks/salesforce.py
+++ b/cumulusci/tasks/salesforce.py
@@ -97,6 +97,10 @@ class BaseSalesforceApiTask(BaseSalesforceTask):
         obj.base_url = obj.base_url.replace('/sobjects/', '/tooling/sobjects/')
         return obj
 
+    def get_tooling_object(self, obj_name):
+        """ get a simple_salesforce tooling object """
+        return self._get_tooling_object(obj_name)
+
 class BaseSalesforceBulkApiTask(BaseSalesforceTask):
     name = 'BaseSalesforceBulkApiTask'
 

--- a/cumulusci/tasks/tests/test_salesforce.py
+++ b/cumulusci/tasks/tests/test_salesforce.py
@@ -10,7 +10,7 @@ from cumulusci.core.config import ConnectedAppOAuthConfig
 from cumulusci.core.config import OrgConfig
 from cumulusci.core.config import TaskConfig
 from cumulusci.core.keychain import BaseProjectKeychain
-from cumulusci.tasks.salesforce import BaseSalesforceToolingApiTask
+from cumulusci.tasks.salesforce import BaseSalesforceApiTask
 from cumulusci.tasks.salesforce import RunApexTests
 from cumulusci.tasks.salesforce import RunApexTestsDebug
 
@@ -38,7 +38,7 @@ class TestBaseSalesforceToolingApiTask(unittest.TestCase):
             self.org_config.instance_url, self.api_version)
 
     def test_get_tooling_object(self):
-        task = BaseSalesforceToolingApiTask(
+        task = BaseSalesforceApiTask(
             self.project_config, self.task_config, self.org_config)
         obj = task._get_tooling_object('TestObject')
         url = self.base_tooling_url + 'sobjects/TestObject/'


### PR DESCRIPTION
# Critical Changes

# Changes
Adds a context manager named ApexLogger which can be used to capture debug logs on the connected salesforce instance.

Usage can be seen in the execute_anon task, which prints back the log with whatever level you desire.

There are some TODOs in the code, and log parsing isn't implemented at all yet. Additionally, once this is complete, the test_run task should be updated. 

At this point, a review of what exists would be great though, and happy to talk any part through.

Capturing (and parsing :/) apex logs is key to pulling performance info automatically.

# Issues Closed
