### PR TITLE
add glob support

### DIFF
--- a/cumulusci/tasks/util.py
+++ b/cumulusci/tasks/util.py
@@ -1,6 +1,7 @@
 import os
 import shutil
 import time
+import glob
 from xml.dom.minidom import parse
 
 from cumulusci.core.tasks import BaseTask
@@ -113,7 +114,8 @@ class Delete(BaseTask):
         path = self.options['path']
         if isinstance(path, list):
             for path_item in path:
-                self._delete(path_item)
+                for match in glob.glob(path_item):
+                    self._delete(match)
    
         if chdir: 
             os.chdir(cwd)


### PR DESCRIPTION
# Critical Changes

# Changes

Support glob expressions in the Delete task, e.g. reducing the need to chdir and more easily clean up build artifacts. 

```
    new_delete:
        description: Delete, but with glob
        class_path: cumulusci.tasks.util.Delete
        options:
            path:
                - package_customizations/**/classes
```

# Issues Closed
