### PR TITLE
Feature/bulkdatafixups

### DIFF
--- a/cumulusci/tasks/bulkdata.py
+++ b/cumulusci/tasks/bulkdata.py
@@ -229,19 +229,19 @@ class LoadData(BaseSalesforceBulkApiTask):
 
         # Build the list of fields to import
         import_fields = fields.keys() + static.keys() + lookups.keys()
-        
+
         if record_type:
             import_fields.append('RecordTypeId')
             # default to the profile assigned recordtype if we can't find any
-            record_type_id = None
-            # now query for the RT name
+            # query for the RT by developer name
             try:
-                query = "select id,developername from recordtype where sobjecttype='{0}' AND developername = '{1}' limit 1"
+                query = "SELECT Id FROM RecordType WHERE SObjectType='{0}'" \
+                    "AND DeveloperName = '{1}' LIMIT 1"
                 record_type_id = self.sf.query(
-                    query.format(mapping.get('sf_object'), mapping.get('record_type'))
+                    query.format(mapping.get('sf_object'), record_type)
                 )['records'][0]['Id']
-            except KeyError:
-                pass
+            except (KeyError, IndexError):
+                record_type_id = None
 
         query = self._query_db(mapping)
 

--- a/cumulusci/tasks/bulkdata.py
+++ b/cumulusci/tasks/bulkdata.py
@@ -232,8 +232,16 @@ class LoadData(BaseSalesforceBulkApiTask):
         
         if record_type:
             import_fields.append('RecordTypeId')
-            # query for record type by dev name
+            # default to the profile assigned recordtype if we can't find any
             record_type_id = None
+            # now query for the RT name
+            try:
+                query = "select id,developername from recordtype where sobjecttype='{0}' AND developername = '{1}' limit 1"
+                record_type_id = self.sf.query(
+                    query.format(mapping.get('sf_object'), mapping.get('record_type'))
+                )['records'][0]['Id']
+            except KeyError:
+                pass
 
         query = self._query_db(mapping)
 

--- a/cumulusci/tasks/salesforce.py
+++ b/cumulusci/tasks/salesforce.py
@@ -107,13 +107,14 @@ class BaseSalesforceToolingApiTask(BaseSalesforceApiTask):
         obj.base_url = obj.base_url.replace('/sobjects/', '/tooling/sobjects/')
         return obj
 
-class BaseSalesforceBulkApiTask(BaseSalesforceTask):
+class BaseSalesforceBulkApiTask(BaseSalesforceApiTask):
     name = 'BaseSalesforceBulkApiTask'
 
     def _init_task(self):
-        self.bulk = self._init_api()
+        super(BaseSalesforceBulkApiTask, self)._init_task()
+        self.bulk = self._init_bulk()
 
-    def _init_api(self):
+    def _init_bulk(self):
         return SalesforceBulk(
             host=self.org_config.instance_url.replace('https://', ''),
             sessionId=self.org_config.access_token,


### PR DESCRIPTION
# Critical Changes

# Changes
- Respect the RecordType developer name in mapping.yml when it exists in the org.
- SalesforceBulkApiTask now inherits from SalesforceBaseApiTask, so the REST API can also be used in bulk tasks.

# Issues Closed
