### PR TITLE
converging enterprise/bulk/tooling into one task class

### DIFF
--- a/cumulusci/tasks/anonymous_apex.py
+++ b/cumulusci/tasks/anonymous_apex.py
@@ -1,10 +1,10 @@
-from cumulusci.tasks.salesforce import BaseSalesforceToolingApiTask
+from cumulusci.tasks.salesforce import BaseSalesforceApiTask
 from cumulusci.core.exceptions import ApexCompilationException
 from cumulusci.core.exceptions import ApexException
 from cumulusci.core.exceptions import SalesforceException
 
 
-class AnonymousApexTask(BaseSalesforceToolingApiTask):
+class AnonymousApexTask(BaseSalesforceApiTask):
     """ Executes a string of anonymous apex. """
     task_options = {
         'apex': {

--- a/cumulusci/tasks/bulkdata.py
+++ b/cumulusci/tasks/bulkdata.py
@@ -1,4 +1,4 @@
-from cumulusci.tasks.salesforce import BaseSalesforceBulkApiTask
+from cumulusci.tasks.salesforce import BaseSalesforceApiTask
 
 import csv
 import time
@@ -46,7 +46,7 @@ def setup_epoch(inspector, table, column_info):
     if isinstance(column_info['type'], types.DateTime):
         column_info['type'] = EpochType()
 
-class DeleteData(BaseSalesforceBulkApiTask):
+class DeleteData(BaseSalesforceApiTask):
 
     task_options = {
         'objects': {
@@ -88,7 +88,7 @@ class DeleteData(BaseSalesforceBulkApiTask):
             for batch in self._upload_batch(delete_job, delete_rows):
                 self.logger.info('    Uploaded batch {}'.format(batch))
                 while not self.bulk.is_batch_done(delete_job, batch):
-                    self.logger.info('      Checking status of batch'.format(batch_num))
+                    self.logger.info('      Checking status of batch {0}'.format(batch_num))
                     time.sleep(10)
                 self.logger.info('      Batch {} complete'.format(batch))
                 batch_num += 1
@@ -120,7 +120,7 @@ class DeleteData(BaseSalesforceBulkApiTask):
 
             yield batch_id
         
-class LoadData(BaseSalesforceBulkApiTask):
+class LoadData(BaseSalesforceApiTask):
 
     task_options = {
         'database_url': {
@@ -325,7 +325,7 @@ class LoadData(BaseSalesforceBulkApiTask):
     def _init_mapping(self):
         self.mapping = hiyapyco.load(self.options['mapping'])
 
-class QueryData(BaseSalesforceBulkApiTask):
+class QueryData(BaseSalesforceApiTask):
     task_options = {
         'database_url': {
             'description': 'A DATABASE_URL where the query output should be written',

--- a/cumulusci/tasks/tests/test_salesforce.py
+++ b/cumulusci/tasks/tests/test_salesforce.py
@@ -10,14 +10,14 @@ from cumulusci.core.config import ConnectedAppOAuthConfig
 from cumulusci.core.config import OrgConfig
 from cumulusci.core.config import TaskConfig
 from cumulusci.core.keychain import BaseProjectKeychain
-from cumulusci.tasks.salesforce import BaseSalesforceToolingApiTask
+from cumulusci.tasks.salesforce import BaseSalesforceApiTask
 from cumulusci.tasks.salesforce import RunApexTests
 from cumulusci.tasks.salesforce import RunApexTestsDebug
 
 
 @patch('cumulusci.tasks.salesforce.BaseSalesforceTask._update_credentials',
     MagicMock(return_value=None))
-class TestBaseSalesforceToolingApiTask(unittest.TestCase):
+class TestSalesforceToolingTask(unittest.TestCase):
 
     def setUp(self):
         self.api_version = 36.0
@@ -38,7 +38,7 @@ class TestBaseSalesforceToolingApiTask(unittest.TestCase):
             self.org_config.instance_url, self.api_version)
 
     def test_get_tooling_object(self):
-        task = BaseSalesforceToolingApiTask(
+        task = BaseSalesforceApiTask(
             self.project_config, self.task_config, self.org_config)
         obj = task._get_tooling_object('TestObject')
         url = self.base_tooling_url + 'sobjects/TestObject/'

--- a/docs/cookbook.rst
+++ b/docs/cookbook.rst
@@ -180,13 +180,13 @@ Verify that the task shows up::
 Query the Tooling API
 ---------------------
 
-For this example, we'll use `BaseSalesforceToolingApiTask` to query ApexClasses via the Tooling API.  This base class initializes a modified version of `simple-salesforce` that points to the Tooling API.  The initalized API wrapper is `self.tooling`.
+In this example, we'll use another API exposed by the `BaseSalesforceApiTask`, the Tooling API! The base task class initializes a wrapper to the enterprise api (`self.sf`), to the bulk api (`self.bulk`), and to the tooling api (`self.tooling`). With a modified `simple-salesforce` instance pointing to the tooling API, we can query for Apex Classes in our org.
 
 Create the file `tasks/tooling.py`::
 
-    from cumulusci.tasks.salesforce import BaseSalesforceToolingApiTask
+    from cumulusci.tasks.salesforce import BaseSalesforceApiTask
 
-    class ListApexClasses(BaseSalesforceToolingApiTask):
+    class ListApexClasses(BaseSalesforceApiTask):
         def _run_task(self):
             res = self.tooling.query('Select Id, Name, NamespacePrefix from ApexClass LIMIT 10')
             for apexclass in res['records']:


### PR DESCRIPTION
# Critical Changes

Removes `cumulusci.tasks.salesforce.BaseSalesforceToolingApiTask` and `cumulusci.tasks.salesforce.BaseSalesforceBulkApiTask` and consolidates their functionality into `cumulusci.tasks.salesforce.BaseSalesforceApiTask`, a single class that has access to the Enterprise, Tooling, and Bulk APIs.

Customer changes: Custom tasks that subclass either `BaseSalesforceToolingApiTask` or `BaseSalesforceBulkApiTask` must now subclass `BaseSalesforceApiTask`. No other change to the task is required.

# Changes

# Issues Closed

fixes #347 - allow bulk, tooling, and enterprise api access from the same base task class