### PR TITLE
Feature/sentry

### DIFF
--- a/cumulusci/cli/cli.py
+++ b/cumulusci/cli/cli.py
@@ -592,8 +592,9 @@ def task_info(config, task_name):
 @click.option('--debug', is_flag=True, help="Drops into pdb, the Python debugger, on an exception")
 @click.option('--debug-before', is_flag=True, help="Drops into the Python debugger right before task start.")
 @click.option('--debug-after', is_flag=True, help="Drops into the Python debugger at task completion.")
+@click.option('--no-prompt', is_flag=True, help="Disables all prompts.  Set for non-interactive mode use such as calling from scripts or CI systems")
 @pass_config
-def task_run(config, task_name, org, o, debug, debug_before, debug_after):
+def task_run(config, task_name, org, o, debug, debug_before, debug_after, no_prompt):
     # Check environment
     check_keychain(config)
 
@@ -647,7 +648,7 @@ def task_run(config, task_name, org, o, debug, debug_before, debug_after):
             traceback.print_exc()
             pdb.post_mortem()
         else:
-            handle_sentry_event(config)
+            handle_sentry_event(config, no_prompt)
             raise
             
     if debug_before:
@@ -672,7 +673,7 @@ def task_run(config, task_name, org, o, debug, debug_before, debug_after):
                 traceback.print_exc()
                 pdb.post_mortem()
             else:
-                handle_sentry_event(config)
+                handle_sentry_event(config, no_prompt)
                 raise
 
     # Save the org config in case it was modified in the task
@@ -685,7 +686,7 @@ def task_run(config, task_name, org, o, debug, debug_before, debug_after):
 
 
     if exception:
-        handle_sentry_event(config)
+        handle_sentry_event(config, no_prompt)
         raise exception
 
 
@@ -725,8 +726,9 @@ def flow_info(config, flow_name):
 @click.option('--debug', is_flag=True, help="Drops into pdb, the Python debugger, on an exception")
 @click.option('-o', nargs=2, multiple=True, help="Pass task specific options for the task as '-o taskname__option value'.  You can specify more than one option by using -o more than once.")
 @click.option('--skip', multiple=True, help="Specify task names that should be skipped in the flow.  Specify multiple by repeating the --skip option")
+@click.option('--no-prompt', is_flag=True, help="Disables all prompts.  Set for non-interactive mode use such as calling from scripts or CI systems")
 @pass_config
-def flow_run(config, flow_name, org, delete_org, debug, o, skip):
+def flow_run(config, flow_name, org, delete_org, debug, o, skip, no_prompt):
     # Check environment
     check_keychain(config)
 
@@ -793,7 +795,7 @@ def flow_run(config, flow_name, org, delete_org, debug, o, skip):
                 traceback.print_exc()
                 pdb.post_mortem()
             else:
-                handle_sentry_event(config)
+                handle_sentry_event(config, no_prompt)
                 raise
 
     # Delete the scratch org if --delete-org was set
@@ -809,7 +811,7 @@ def flow_run(config, flow_name, org, delete_org, debug, o, skip):
         config.keychain.set_org(org, org_config)
 
     if exception:
-        handle_sentry_event(config)
+        handle_sentry_event(config, no_prompt)
         raise exception
 
 flow.add_command(flow_list)

--- a/cumulusci/core/config.py
+++ b/cumulusci/core/config.py
@@ -9,6 +9,7 @@ import re
 from collections import OrderedDict
 
 import hiyapyco
+import raven
 import sarge
 from simple_salesforce import Salesforce
 import yaml
@@ -20,6 +21,7 @@ from github3 import login
 from Crypto import Random
 from Crypto.Cipher import AES
 
+import cumulusci
 from cumulusci.core.exceptions import ConfigError
 from cumulusci.core.exceptions import NotInProject
 from cumulusci.core.exceptions import KeychainConnectedAppNotFound
@@ -243,6 +245,40 @@ class BaseProjectConfig(BaseTaskFlowConfig):
                         break
 
         return commit_sha
+
+    @property
+    def use_sentry(self):
+        try:
+            self.keychain.get_service('sentry') 
+            return True
+        except ServiceNotConfigured:
+            return False
+
+    def init_sentry(self, ):
+        """ Initializes sentry.io error logging for this session """
+        if not self.use_sentry:
+            return
+            
+        sentry_config = self.keychain.get_service('sentry') 
+
+        tags = {
+            'repo': self.repo_name,
+            'branch': self.repo_branch,
+            'commit': self.repo_commit,
+            'cci version': cumulusci.__version__,
+        }
+        tags.update(self.config.get('sentry_tags',{}))
+
+        env = self.config.get('sentry_environment', 'CumulusCI CLI')
+
+        self.sentry = raven.Client(
+            dsn = sentry_config.dsn,
+            environment = env,
+            tags = tags,
+            processors = (
+                'raven.processors.SanitizePasswordsProcessor',
+            ),
+        )
     
     def get_github_api(self):
         github_config = self.keychain.get_service('github')

--- a/cumulusci/core/config.py
+++ b/cumulusci/core/config.py
@@ -27,6 +27,8 @@ from cumulusci.core.exceptions import NotInProject
 from cumulusci.core.exceptions import KeychainConnectedAppNotFound
 from cumulusci.core.exceptions import ProjectConfigNotFound
 from cumulusci.core.exceptions import ScratchOrgException
+from cumulusci.core.exceptions import ServiceNotConfigured
+from cumulusci.core.exceptions import ServiceNotValid
 from cumulusci.core.exceptions import SOQLQueryException
 from cumulusci.core.exceptions import KeychainNotFound
 from cumulusci.oauth.salesforce import SalesforceOAuth2
@@ -252,6 +254,8 @@ class BaseProjectConfig(BaseTaskFlowConfig):
             self.keychain.get_service('sentry') 
             return True
         except ServiceNotConfigured:
+            return False
+        except ServiceNotValid:
             return False
 
     def init_sentry(self, ):

--- a/cumulusci/core/keychain.py
+++ b/cumulusci/core/keychain.py
@@ -129,7 +129,7 @@ class BaseProjectKeychain(BaseConfig):
 
     def set_service(self, name, service_config, project=False):
         """ Store a ServiceConfig in the keychain """
-        if name not in self.project_config.services:
+        if not self.project_config.services or name not in self.project_config.services:
             self._raise_service_not_valid(name)
         self._validate_service(name, service_config)
         self._set_service(name, service_config, project)
@@ -147,7 +147,7 @@ class BaseProjectKeychain(BaseConfig):
         :rtype ServiceConfig
         :return the configured Service
         """
-        if name not in self.project_config.services:
+        if not self.project_config.services or name not in self.project_config.services:
             self._raise_service_not_valid(name)
         if name not in self.services:
             self._raise_service_not_configured(name)

--- a/cumulusci/cumulusci.yml
+++ b/cumulusci/cumulusci.yml
@@ -447,6 +447,21 @@ services:
       api_key:
         description: The Saucelabs api key to use for tasks  
         required: True
+  sentry:
+    description: Configure connection to sentry.io for error tracking
+    attributes:
+      dsn:
+        description: "The sentry DSN for connecting to the API, see https://docs.sentry.io/quickstart/#configure-the-dsn"
+        required: True
+      api_key:
+        description: "The sentry web api auth key for your account, see https://docs.sentry.io/api/auth/"
+        required: True
+      org_slug:
+        description: "The abbreviated organization name used in the your sentry urls"
+        required: True
+      project_slug:
+        description: "The abbreviated project slug used in sentry urls to the project"
+        required: True
 
 project:
     name:

--- a/cumulusci/tasks/util.py
+++ b/cumulusci/tasks/util.py
@@ -135,3 +135,80 @@ class Delete(BaseTask):
                 'Deleting file {}'.format(path)
             )
             os.remove(path)
+
+
+class FindReplace(BaseTask):
+    task_options = {
+        'find': {
+            'description': "The string to search for",
+            'required': True,
+        },
+        'replace': {
+            'description': "The string to replace matches with. Defaults to an empty string",
+            'required': True,
+        },
+        'path': {
+            'description': "The path to recursively search",
+            'required': True,
+        },
+        'file_pattern': {
+            'description': "A UNIX like filename pattern used for matching filenames.  See python fnmatch docs for syntax.  Defaults to *",
+            'required': True,
+        },
+        'max': {
+            'description': "The max number of matches to replace.  Defaults to replacing all matches.",
+        },
+    }
+    
+    def _init_options(self):
+        if 'replace' not in self.options:
+            self.options['replace'] = ''
+        if 'file_pattern' not in self.options:
+            self.options['file_pattern'] = '*'
+
+    def _run_task(self):
+        kwargs = {}
+        if 'max' in self.options:
+            kwargs['max'] = self.options['max']
+        findReplace(
+            find = self.options['find'],
+            replace = self.options['replace'],
+            directory = self.options['path'],
+            filePattern = self.options['file_pattern'],
+            logger = self.logger,
+            **kwargs
+        )
+
+find_replace_regex_options = FindReplace.task_options.copy()
+del find_repalce_regex_options['max']
+
+class FindReplaceRegex(FindReplace):
+    task_options = find_replace_regex_options
+            
+    def _run_task(self):
+        findReplaceRegex(
+            find = self.options['find'],
+            replace = self.options['replace'],
+            directory = self.options['path'],
+            filePattern = self.options['file_pattern'],
+            logger = self.logger,
+        )
+
+class CopyFile(BaseTask):
+    task_options = {
+        'src': {
+            'description': 'The path to the source file to copy',
+            'required': True,
+        },
+        'dest': {
+            'description': 'The destination path where the src file should be copied',
+            'required': True,
+        },
+    }
+
+    def _run_task(self):
+        self.logger.info('Copying file {src} to {dest}'.format(**self.options))
+        shutil.copyfile(
+            src = self.options['src'],
+            dst = self.options['dest'],
+        )

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ lxml==3.8.0
 mock
 plaintable==0.1.1
 sarge==0.1.4
+raven==6.1.0
 requests[security]==2.9.1
 responses==0.5.1
 rst2ansi==0.1.5

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ requirements = [
     'docutils>=0.13.1',
     'github3.py==0.9.6',
     'plaintable==0.1.1',
+    'raven>=0.6.1',
     'requests[security]>=2.9.1',
     'responses>=0.5.1',
     'rst2ansi>=0.1.5',


### PR DESCRIPTION
# Critical Changes

* If you have the sentry service configured and use `cci task run` or `cci flow run` in the CLI in non-interactive mode (i.e. a script or CI server), be sure to set the `--no-prompt` option flag.

# Changes

* Integration with [sentry.io](sentry.io)
    * New service `sentry` now available to configure via `cci service connect sentry`
    * All exceptions raised in BaseTask.__call__ are logged to sentry if the service is configured
    * `cci task run` and `cci flow run` now notify you if a sentry event was created from an error, provide you the url to view it, and prompt you to open it in the browser automatically.
    * Custom sentry environment and tags can be injected into the project config as `project_config.config['sentry_environment'] = 'YOUR ENVIRONMENT'` and `project_config.config['sentry_tags'] = {'tag1': 'value'}`

# Issues Closed
