### PR TITLE
Specify release notes parser config in yml

### DIFF
--- a/cumulusci/cumulusci.yml
+++ b/cumulusci/cumulusci.yml
@@ -382,7 +382,7 @@ flows:
                 ignore_failure: True  # Attempt to generate release notes but don't fail build
                 options:
                     link_pr: True
-                    publish: True
+                    dry_run: False
                     tag: ^^github_release.tag_name
             4:
                 task: github_master_to_feature

--- a/cumulusci/cumulusci.yml
+++ b/cumulusci/cumulusci.yml
@@ -485,6 +485,17 @@ project:
         prefix_feature: feature/
         prefix_beta: beta/
         prefix_release: release/
+        release_notes:
+            parsers:
+                1:
+                    class_path: cumulusci.tasks.release_notes.parser.GithubLinesParser
+                    title: Critical Changes
+                2:
+                    class_path: cumulusci.tasks.release_notes.parser.GithubLinesParser
+                    title: Changes
+                3:
+                    class_path: cumulusci.tasks.release_notes.parser.GithubIssuesParser
+                    title: Issues Closed
     test:
         name_match: '%_TEST%'
     apexdoc:

--- a/cumulusci/tasks/release_notes/generator.py
+++ b/cumulusci/tasks/release_notes/generator.py
@@ -111,7 +111,7 @@ class GithubReleaseNotesGenerator(BaseReleaseNotesGenerator, GithubApiMixin):
             current_tag,
             last_tag=None,
             link_pr=False,
-            publish=False,
+            dry_run=True,
             has_issues=True,
         ):
         self.github_info = github_info
@@ -119,7 +119,7 @@ class GithubReleaseNotesGenerator(BaseReleaseNotesGenerator, GithubApiMixin):
         self.current_tag = current_tag
         self.last_tag = last_tag
         self.link_pr = link_pr
-        self.do_publish = publish
+        self.dry_run = dry_run
         self.has_issues = has_issues
         self.lines_parser_class = None
         self.issues_parser_class = None
@@ -127,7 +127,7 @@ class GithubReleaseNotesGenerator(BaseReleaseNotesGenerator, GithubApiMixin):
 
     def __call__(self):
         content = super(GithubReleaseNotesGenerator, self).__call__()
-        if self.do_publish:
+        if not self.dry_run:
             content = self.publish(content)
         return content
 

--- a/cumulusci/tasks/release_notes/generator.py
+++ b/cumulusci/tasks/release_notes/generator.py
@@ -7,13 +7,10 @@ import json
 from datetime import datetime
 from distutils.version import LooseVersion
 
+from cumulusci.core.utils import import_class
 from cumulusci.tasks.release_notes.github_api import GithubApiMixin
 from cumulusci.tasks.release_notes.parser import ChangeNotesLinesParser
 from cumulusci.tasks.release_notes.parser import IssuesParser
-from cumulusci.tasks.release_notes.parser import GithubIssuesParser
-from cumulusci.tasks.release_notes.parser import GithubLinesParser
-from cumulusci.tasks.release_notes.parser import GithubLinkingLinesParser
-from cumulusci.tasks.release_notes.parser import CommentingGithubIssuesParser
 from cumulusci.tasks.release_notes.provider import StaticChangeNotesProvider
 from cumulusci.tasks.release_notes.provider import DirectoryChangeNotesProvider
 from cumulusci.tasks.release_notes.provider import GithubChangeNotesProvider
@@ -105,41 +102,39 @@ class DirectoryReleaseNotesGenerator(BaseReleaseNotesGenerator):
         return DirectoryChangeNotesProvider(self, self.directory)
 
 
-class GithubReleaseNotesGenerator(BaseReleaseNotesGenerator):
+class GithubReleaseNotesGenerator(BaseReleaseNotesGenerator, GithubApiMixin):
 
     def __init__(
             self,
             github_info,
+            parser_config,
             current_tag,
             last_tag=None,
             link_pr=False,
+            publish=False,
             has_issues=True,
         ):
         self.github_info = github_info
+        self.parser_config = parser_config
         self.current_tag = current_tag
         self.last_tag = last_tag
         self.link_pr = link_pr
+        self.do_publish = publish
         self.has_issues = has_issues
         self.lines_parser_class = None
         self.issues_parser_class = None
         super(GithubReleaseNotesGenerator, self).__init__()
 
+    def __call__(self):
+        content = super(GithubReleaseNotesGenerator, self).__call__()
+        if self.do_publish:
+            content = self.publish(content)
+        return content
+
     def _init_parsers(self):
-        self._set_classes()
-        self.parsers.append(self.lines_parser_class(
-            self,
-            'Critical Changes',
-        ))
-        self.parsers.append(self.lines_parser_class(
-            self,
-            'Changes',
-        ))
-        if self.has_issues:
-            self.parsers.append(self.issues_parser_class(
-                self,
-                'Issues Closed',
-                link_pr=self.link_pr,
-            ))
+        for cfg in self.parser_config:
+            parser_class = import_class(cfg['class_path'])
+            self.parsers.append(parser_class(self, cfg['title']))
 
     def _init_change_notes(self):
         return GithubChangeNotesProvider(
@@ -148,36 +143,9 @@ class GithubReleaseNotesGenerator(BaseReleaseNotesGenerator):
             self.last_tag
         )
 
-    def _set_classes(self):
-        self.lines_parser_class = (
-            GithubLinkingLinesParser if self.link_pr else GithubLinesParser
-        )
-        self.issues_parser_class = (
-            GithubIssuesParser if self.has_issues else IssuesParser
-        )
-
-
-class PublishingGithubReleaseNotesGenerator(GithubReleaseNotesGenerator, GithubApiMixin):
-
-    def __call__(self):
-        content = super(PublishingGithubReleaseNotesGenerator, self).__call__()
-        return self.publish(content)
-
-    def publish(self, content):
-        release = self._get_release()
-        return self._update_release(release, content)
-
     def _get_release(self):
         # Query for the release
         return self.call_api('/releases/tags/{}'.format(self.current_tag))
-
-    def _set_classes(self):
-        self.lines_parser_class = (
-            GithubLinkingLinesParser if self.link_pr else GithubLinesParser
-        )
-        self.issues_parser_class = (
-            CommentingGithubIssuesParser if self.has_issues else IssuesParser
-        )
 
     def _update_release(self, release, content):
 
@@ -237,3 +205,7 @@ class PublishingGithubReleaseNotesGenerator(GithubReleaseNotesGenerator, GithubA
             resp = self.call_api('/releases', data=release)
 
         return release['body']
+
+    def publish(self, content):
+        release = self._get_release()
+        return self._update_release(release, content)

--- a/cumulusci/tasks/release_notes/parser.py
+++ b/cumulusci/tasks/release_notes/parser.py
@@ -206,7 +206,7 @@ class GithubIssuesParser(IssuesParser, ParserGithubApiMixin):
         self.link_pr = release_notes_generator.link_pr
         self.pr_number = None
         self.pr_url = None
-        self.do_publish = release_notes_generator.do_publish
+        self.dry_run = release_notes_generator.dry_run
 
     def _add_line(self, line):
         # find issue numbers per line
@@ -246,7 +246,7 @@ class GithubIssuesParser(IssuesParser, ParserGithubApiMixin):
         return u'\r\n'.join(content)
 
     def _get_issue_info(self, issue_number):
-        if self.do_publish:
+        if not self.dry_run:
             self._add_issue_comment(issue_number)
         response = self.call_api('/issues/{}'.format(issue_number))
         if 'message' in response:

--- a/cumulusci/tasks/release_notes/parser.py
+++ b/cumulusci/tasks/release_notes/parser.py
@@ -187,8 +187,10 @@ class ParserGithubApiMixin(GithubApiMixin):
 
 
 class GithubIssuesParser(IssuesParser, ParserGithubApiMixin):
-    message_prod = 'Included in production release'
-    message_beta = 'Included in beta release'
+    ISSUE_COMMENT = {
+        'beta': 'Included in beta release',
+        'prod': 'Included in production release',
+    }
 
     def __init__(self, release_notes_generator, title, issue_regex=None):
         super(GithubIssuesParser, self).__init__(
@@ -266,22 +268,22 @@ class GithubIssuesParser(IssuesParser, ParserGithubApiMixin):
 
         for comment in gh_issue_comments:
             if current_tag_info['is_prod']:
-                if comment['body'].startswith(self.message_prod):
+                if comment['body'].startswith(self.ISSUE_COMMENT['prod']):
                     has_comment = True
             elif current_tag_info['is_beta']:
-                if comment['body'].startswith(self.message_beta):
+                if comment['body'].startswith(self.ISSUE_COMMENT['beta']):
                     has_comment = True
 
         if not has_comment:
             data = {}
             if current_tag_info['is_prod']:
                 data['body'] = '{} {}'.format(
-                    self.message_prod,
+                    self.ISSUE_COMMENT['prod'],
                     current_tag_info['version_number'],
                 )
             elif current_tag_info['is_beta']:
                 data['body'] = '{} {}'.format(
-                    self.message_beta,
+                    self.ISSUE_COMMENT['beta'],
                     current_tag_info['version_number'],
                 )
 

--- a/cumulusci/tasks/release_notes/task.py
+++ b/cumulusci/tasks/release_notes/task.py
@@ -1,7 +1,6 @@
 from cumulusci.core.utils import process_bool_arg
 from cumulusci.tasks.github import BaseGithubTask
-from generator import GithubReleaseNotesGenerator
-from generator import PublishingGithubReleaseNotesGenerator
+from cumulusci.tasks.release_notes.generator import GithubReleaseNotesGenerator
 
 
 class GithubReleaseNotes(BaseGithubTask):
@@ -13,8 +12,8 @@ class GithubReleaseNotes(BaseGithubTask):
             'required': True,
         },
         'publish': {
-            'description': ('If True, publishes to the release matching the' +
-                ' tag release notes were generated for.'),
+            'description': ('If True, publish to the release matching the' +
+                ' given tag and comment on issues with release info.'),
         },
         'last_tag': {
             'description': ('Override the last release tag. This is useful' +
@@ -38,16 +37,13 @@ class GithubReleaseNotes(BaseGithubTask):
             'prefix_prod': self.project_config.project__git__prefix_release,
         }
 
-        if process_bool_arg(self.options.get('publish', False)):
-            generator_class = PublishingGithubReleaseNotesGenerator
-        else:
-            generator_class = GithubReleaseNotesGenerator
-
-        generator = generator_class(
+        generator = GithubReleaseNotesGenerator(
             github_info,
+            self.project_config.project__git__release_notes__parsers.values(),
             self.options['tag'],
             self.options.get('last_tag'),
             process_bool_arg(self.options.get('link_pr', False)),
+            process_bool_arg(self.options.get('publish', False)),
             self.get_repo().has_issues,
         )
 

--- a/cumulusci/tasks/release_notes/task.py
+++ b/cumulusci/tasks/release_notes/task.py
@@ -11,10 +11,6 @@ class GithubReleaseNotes(BaseGithubTask):
                 ' Ex: release/1.2'),
             'required': True,
         },
-        'publish': {
-            'description': ('If True, publish to the release matching the' +
-                ' given tag and comment on issues with release info.'),
-        },
         'last_tag': {
             'description': ('Override the last release tag. This is useful' +
                 ' to generate release notes if you skipped one or more' +
@@ -23,6 +19,9 @@ class GithubReleaseNotes(BaseGithubTask):
         'link_pr': {
             'description': ('If True, insert link to source pull request at' +
                 ' end of each line.'),
+        },
+        'dry_run': {
+            'description': 'Execute a dry run if True (default=True)',
         },
     }
 
@@ -43,7 +42,7 @@ class GithubReleaseNotes(BaseGithubTask):
             self.options['tag'],
             self.options.get('last_tag'),
             process_bool_arg(self.options.get('link_pr', False)),
-            process_bool_arg(self.options.get('publish', False)),
+            process_bool_arg(self.options.get('dry_run', True)),
             self.get_repo().has_issues,
         )
 

--- a/cumulusci/tasks/release_notes/tests/test_generator.py
+++ b/cumulusci/tasks/release_notes/tests/test_generator.py
@@ -262,7 +262,7 @@ class TestPublishingGithubReleaseNotesGenerator(unittest.TestCase, GithubApiTest
             PARSER_CONFIG,
             current_tag,
             last_tag,
-            publish=True,
+            dry_run=False,
         )
         return generator
 

--- a/cumulusci/tasks/release_notes/tests/test_parser.py
+++ b/cumulusci/tasks/release_notes/tests/test_parser.py
@@ -275,7 +275,7 @@ class TestCommentingGithubIssuesParser(unittest.TestCase, GithubApiTestMixin):
             self.github_info.copy(),
             PARSER_CONFIG,
             tag,
-            publish=True,
+            dry_run=False,
         )
         return generator
 
@@ -349,7 +349,7 @@ class TestCommentingGithubIssuesParser(unittest.TestCase, GithubApiTestMixin):
             issue_number,
         )
         expected_comment_1 = self._get_expected_issue_comment(
-            GithubIssuesParser.message_beta,
+            GithubIssuesParser.ISSUE_COMMENT['beta'],
         )
         expected_comments = [
             expected_comment_1,
@@ -420,7 +420,7 @@ class TestCommentingGithubIssuesParser(unittest.TestCase, GithubApiTestMixin):
         )
         expected_comment_1 = self._get_expected_issue_comment(
             '{} {}'.format(
-                GithubIssuesParser.message_beta,
+                GithubIssuesParser.ISSUE_COMMENT['beta'],
                 self.version_number_beta,
             )
         )
@@ -471,7 +471,7 @@ class TestCommentingGithubIssuesParser(unittest.TestCase, GithubApiTestMixin):
             issue_number,
         )
         expected_comment_1 = self._get_expected_issue_comment(
-            GithubIssuesParser.message_prod,
+            GithubIssuesParser.ISSUE_COMMENT['prod'],
         )
         expected_comments = [
             expected_comment_1,
@@ -542,7 +542,7 @@ class TestCommentingGithubIssuesParser(unittest.TestCase, GithubApiTestMixin):
         )
         expected_comment_1 = self._get_expected_issue_comment(
             '{} {}'.format(
-                GithubIssuesParser.message_prod,
+                GithubIssuesParser.ISSUE_COMMENT['prod'],
                 self.version_number_prod,
             )
         )

--- a/cumulusci/tasks/release_notes/tests/test_provider.py
+++ b/cumulusci/tasks/release_notes/tests/test_provider.py
@@ -20,6 +20,20 @@ from cumulusci.tasks.release_notes.tests.util_github_api import GithubApiTestMix
 
 __location__ = os.path.split(os.path.realpath(__file__))[0]
 date_format = '%Y-%m-%dT%H:%M:%SZ'
+PARSER_CONFIG = [
+    {
+        'class_path': 'cumulusci.tasks.release_notes.parser.GithubLinesParser',
+        'title': 'Critical Changes',
+    },
+    {
+        'class_path': 'cumulusci.tasks.release_notes.parser.GithubLinesParser',
+        'title': 'Changes',
+    },
+    {
+        'class_path': 'cumulusci.tasks.release_notes.parser.GithubIssuesParser',
+        'title': 'Issues Closed',
+    },
+]
 
 
 class TestBaseChangeNotesProvider(unittest.TestCase):
@@ -115,6 +129,7 @@ class TestGithubChangeNotesProvider(unittest.TestCase, GithubApiTestMixin):
     def _create_generator(self, current_tag, last_tag=None):
         generator = GithubReleaseNotesGenerator(
             self.github_info.copy(),
+            PARSER_CONFIG,
             current_tag,
             last_tag=last_tag
         )


### PR DESCRIPTION
Need to support per-project parser customizations for release notes. YAML to the rescue!

Once this is merged and deployed to mrbelvedereci, SAL has an associated change to take advantage (https://github.com/SalesforceFoundation/sal/commit/a61684fc871954dab029debe1907c2903a303293). Otherwise all other repos should work without any modifications.

Tested in multiple repos with lots of option toggling.