### PR TITLE
Don't hide input when entering client secret on windows machines

### DIFF
--- a/cumulusci/cli/cli.py
+++ b/cumulusci/cli/cli.py
@@ -526,7 +526,7 @@ def org_connected_app(config):
 
 @click.command(name='config_connected_app', help="Configures the connected app used for connecting to Salesforce orgs")
 @click.option('--client_id', help="The Client ID from the connected app", prompt=True)
-@click.option('--client_secret', help="The Client Secret from the connected app", prompt=True, hide_input=True)
+@click.option('--client_secret', help="The Client Secret from the connected app", prompt=True, hide_input=(False if os.name == 'nt' else True))
 @click.option('--callback_url', help="The callback_url configured on the Connected App", default='http://localhost:8080/callback')
 @click.option('--project', help='Set if storing encrypted keychain file in project directory', is_flag=True)
 @pass_config


### PR DESCRIPTION
We hide the input when entering the client secret in `cci org config_connected_app`. Apparently this breaks things on Windows and the value stored in client secret is just `u'\x16'`. Confirmed that settings hide_input=False gets around the problem. I'd like to gather more evidence and file an issue in [click](https://github.com/pallets/click) but in the meantime this should unblock those working in Windows.

@cdcarter asking for your review just to get your opinion if showing the input is a big deal. I think it's okay since it's just local to the shell session.