### PR TITLE
retrieve test results with api38

### DIFF
--- a/cumulusci/tasks/apex/testrunner.py
+++ b/cumulusci/tasks/apex/testrunner.py
@@ -42,6 +42,8 @@ WHERE AsyncApexJobId='{}'
 
 class RunApexTests(BaseSalesforceApiTask):
     """ Task to run Apex tests with the Tooling API and report results """
+    api_version = '38.0'
+    name = 'RunApexTests'
     task_options = {
         'test_name_match': {
             'description': ('Query to find Apex test classes to run ' +


### PR DESCRIPTION
Pin testrunner with API v38.0 to get at the ApexTestResultLimit object and fields on ApexTestResult.