### PR TITLE
Make dry run defaults False

### DIFF
--- a/cumulusci/cumulusci.yml
+++ b/cumulusci/cumulusci.yml
@@ -382,7 +382,6 @@ flows:
                 ignore_failure: True  # Attempt to generate release notes but don't fail build
                 options:
                     link_pr: True
-                    dry_run: False
                     tag: ^^github_release.tag_name
             4:
                 task: github_master_to_feature

--- a/cumulusci/tasks/github.py
+++ b/cumulusci/tasks/github.py
@@ -227,7 +227,7 @@ class CommitApexDocs(BaseGithubTask):
             'default=project__apexdoc__repo_dir',
         },
         'dry_run': {
-            'description': 'Execute a dry run if True (default=True)',
+            'description': 'Execute a dry run if True (default=False)',
         },
         'commit_message': {
             'description': 'Message for commit; default="Update Apex docs"',
@@ -256,7 +256,7 @@ class CommitApexDocs(BaseGithubTask):
             'dir_repo',
             self.project_config.project__apexdoc__repo_dir,
         )
-        dry_run = process_bool_arg(self.options.get('dry_run', True))
+        dry_run = process_bool_arg(self.options.get('dry_run', False))
         commit_message = self.options.get('commit_message', 'Update Apex docs')
 
         # get API

--- a/cumulusci/tasks/github_commit.py
+++ b/cumulusci/tasks/github_commit.py
@@ -27,7 +27,7 @@ class CommitDir(object):
             branch,
             repo_dir=None,
             commit_message=None,
-            dry_run=True,
+            dry_run=False,
         ):
         """
         local_dir: path to local directory to commit

--- a/cumulusci/tasks/release_notes/generator.py
+++ b/cumulusci/tasks/release_notes/generator.py
@@ -111,7 +111,7 @@ class GithubReleaseNotesGenerator(BaseReleaseNotesGenerator, GithubApiMixin):
             current_tag,
             last_tag=None,
             link_pr=False,
-            dry_run=True,
+            dry_run=False,
             has_issues=True,
         ):
         self.github_info = github_info

--- a/cumulusci/tasks/release_notes/task.py
+++ b/cumulusci/tasks/release_notes/task.py
@@ -21,7 +21,7 @@ class GithubReleaseNotes(BaseGithubTask):
                 ' end of each line.'),
         },
         'dry_run': {
-            'description': 'Execute a dry run if True (default=True)',
+            'description': 'Execute a dry run if True (default=False)',
         },
     }
 
@@ -42,7 +42,7 @@ class GithubReleaseNotes(BaseGithubTask):
             self.options['tag'],
             self.options.get('last_tag'),
             process_bool_arg(self.options.get('link_pr', False)),
-            process_bool_arg(self.options.get('dry_run', True)),
+            process_bool_arg(self.options.get('dry_run', False)),
             self.get_repo().has_issues,
         )
 

--- a/cumulusci/tasks/release_notes/tests/test_generator.py
+++ b/cumulusci/tasks/release_notes/tests/test_generator.py
@@ -262,7 +262,6 @@ class TestPublishingGithubReleaseNotesGenerator(unittest.TestCase, GithubApiTest
             PARSER_CONFIG,
             current_tag,
             last_tag,
-            dry_run=False,
         )
         return generator
 

--- a/cumulusci/tasks/release_notes/tests/test_parser.py
+++ b/cumulusci/tasks/release_notes/tests/test_parser.py
@@ -240,6 +240,7 @@ class TestGithubIssuesParser(unittest.TestCase, GithubApiTestMixin):
             self.github_info.copy(),
             PARSER_CONFIG,
             'prod/1.1',
+            dry_run=True,
         )
         return generator
 
@@ -275,7 +276,6 @@ class TestCommentingGithubIssuesParser(unittest.TestCase, GithubApiTestMixin):
             self.github_info.copy(),
             PARSER_CONFIG,
             tag,
-            dry_run=False,
         )
         return generator
 


### PR DESCRIPTION
Everywhere we have a "dry run" option the default should be False. This makes it more in line with how dry run works in popular tools e.g. `git remote prune origin --dry-run`.