### PR TITLE
Change github_release_notes task option dry_run (back) to publish

### DIFF
--- a/cumulusci/cumulusci.yml
+++ b/cumulusci/cumulusci.yml
@@ -382,6 +382,7 @@ flows:
                 ignore_failure: True  # Attempt to generate release notes but don't fail build
                 options:
                     link_pr: True
+                    publish: True
                     tag: ^^github_release.tag_name
             4:
                 task: github_master_to_feature

--- a/cumulusci/tasks/release_notes/generator.py
+++ b/cumulusci/tasks/release_notes/generator.py
@@ -111,7 +111,7 @@ class GithubReleaseNotesGenerator(BaseReleaseNotesGenerator, GithubApiMixin):
             current_tag,
             last_tag=None,
             link_pr=False,
-            dry_run=False,
+            publish=False,
             has_issues=True,
         ):
         self.github_info = github_info
@@ -119,7 +119,7 @@ class GithubReleaseNotesGenerator(BaseReleaseNotesGenerator, GithubApiMixin):
         self.current_tag = current_tag
         self.last_tag = last_tag
         self.link_pr = link_pr
-        self.dry_run = dry_run
+        self.do_publish = publish
         self.has_issues = has_issues
         self.lines_parser_class = None
         self.issues_parser_class = None
@@ -127,7 +127,7 @@ class GithubReleaseNotesGenerator(BaseReleaseNotesGenerator, GithubApiMixin):
 
     def __call__(self):
         content = super(GithubReleaseNotesGenerator, self).__call__()
-        if not self.dry_run:
+        if self.do_publish:
             content = self.publish(content)
         return content
 

--- a/cumulusci/tasks/release_notes/parser.py
+++ b/cumulusci/tasks/release_notes/parser.py
@@ -206,7 +206,7 @@ class GithubIssuesParser(IssuesParser, ParserGithubApiMixin):
         self.link_pr = release_notes_generator.link_pr
         self.pr_number = None
         self.pr_url = None
-        self.dry_run = release_notes_generator.dry_run
+        self.publish = release_notes_generator.do_publish
 
     def _add_line(self, line):
         # find issue numbers per line
@@ -246,7 +246,7 @@ class GithubIssuesParser(IssuesParser, ParserGithubApiMixin):
         return u'\r\n'.join(content)
 
     def _get_issue_info(self, issue_number):
-        if not self.dry_run:
+        if self.publish:
             self._add_issue_comment(issue_number)
         response = self.call_api('/issues/{}'.format(issue_number))
         if 'message' in response:

--- a/cumulusci/tasks/release_notes/task.py
+++ b/cumulusci/tasks/release_notes/task.py
@@ -20,8 +20,8 @@ class GithubReleaseNotes(BaseGithubTask):
             'description': ('If True, insert link to source pull request at' +
                 ' end of each line.'),
         },
-        'dry_run': {
-            'description': 'Execute a dry run if True (default=False)',
+        'publish': {
+            'description': 'Publish to GitHub release if True (default=False)',
         },
     }
 
@@ -42,7 +42,7 @@ class GithubReleaseNotes(BaseGithubTask):
             self.options['tag'],
             self.options.get('last_tag'),
             process_bool_arg(self.options.get('link_pr', False)),
-            process_bool_arg(self.options.get('dry_run', False)),
+            process_bool_arg(self.options.get('publish', False)),
             self.get_repo().has_issues,
         )
 

--- a/cumulusci/tasks/release_notes/tests/test_parser.py
+++ b/cumulusci/tasks/release_notes/tests/test_parser.py
@@ -240,7 +240,6 @@ class TestGithubIssuesParser(unittest.TestCase, GithubApiTestMixin):
             self.github_info.copy(),
             PARSER_CONFIG,
             'prod/1.1',
-            dry_run=True,
         )
         return generator
 
@@ -276,6 +275,7 @@ class TestCommentingGithubIssuesParser(unittest.TestCase, GithubApiTestMixin):
             self.github_info.copy(),
             PARSER_CONFIG,
             tag,
+            publish=True,
         )
         return generator
 


### PR DESCRIPTION
Used this task today with dry_run option and it felt wrong. I think it makes more sense to have a "publish" option default=False. It used to be like this so this would just go back to how it was.