### PR TITLE
100% test coverage for core/flow.py

### DIFF
--- a/cumulusci/core/tests/test_flows.py
+++ b/cumulusci/core/tests/test_flows.py
@@ -205,18 +205,12 @@ class TestBaseFlow(unittest.TestCase):
         # the number of tasks in the flow should be 1 instead of 2
         self.assertEquals(1, len(flow.task_results))
 
-    def test_find_task_by_name_missing(self):
+    def test_find_task_by_name_no_tasks(self):
         """ The _find_task_by_name method skips tasks that don't exist """
 
         # instantiate a flow with two tasks
         flow_config = FlowConfig({
             'description': 'Run two tasks',
-            'tasks': {
-                1: {'task': 'pass_name'},
-                2: {'task': 'name_response', 'options': {
-                    'response': '^^pass_name.name'
-                }},
-            }
         })
 
         flow = BaseFlow(
@@ -226,7 +220,6 @@ class TestBaseFlow(unittest.TestCase):
         )
 
         self.assertEquals(None, flow._find_task_by_name('missing'))
-        self.assertEquals(None, flow._find_task_by_name('name_response'))
 
     def test_find_task_by_name_not_first(self):
         """ The _find_task_by_name method skips tasks that don't exist """

--- a/cumulusci/core/tests/test_flows.py
+++ b/cumulusci/core/tests/test_flows.py
@@ -297,7 +297,7 @@ class TestBaseFlow(unittest.TestCase):
         self.assertRaises(Exception, flow)
 
     def test_task_raises_exception_ignore(self):
-        """ A flow aborts when a task raises an exception """
+        """ A flow continues when a task configured with ignore_failure raises an exception """
 
         flow_config = FlowConfig({
             'description': 'Run a task',

--- a/cumulusci/core/tests/test_flows.py
+++ b/cumulusci/core/tests/test_flows.py
@@ -110,7 +110,7 @@ class TestBaseFlow(unittest.TestCase):
         # the flow results for the second task should be 'name'
         self.assertEquals('supername', flow.task_results[1])
 
-    def test_pass_task_options(self):
+    def test_task_options(self):
         """ A flow can accept task options and pass them to the task. """
 
         # instantiate a flow with two tasks
@@ -134,6 +134,33 @@ class TestBaseFlow(unittest.TestCase):
         flow()
         # the flow results for the second task should be 'name'
         self.assertEquals('bar', flow.task_results[0])
+
+    def test_skip_task(self):
+        """ A flow can receive during init a list of tasks to skip """
+
+        # instantiate a flow with two tasks
+        flow_config = FlowConfig({
+            'description': 'Run two tasks',
+            'tasks': {
+                1: {'task': 'pass_name'},
+                2: {'task': 'name_response', 'options': {
+                    'response': '^^pass_name.name'
+                }},
+            }
+        })
+
+        flow = BaseFlow(
+            self.project_config,
+            flow_config,
+            self.org_config,
+            skip=['name_response'],
+        )
+
+        # run the flow
+        flow()
+
+        # the flow results for the second task should be 'name'
+        self.assertEquals(1, len(flow.task_results))
 
     def test_call_no_tasks(self):
         """ A flow with no tasks will have no responses. """

--- a/cumulusci/core/tests/test_flows.py
+++ b/cumulusci/core/tests/test_flows.py
@@ -143,7 +143,9 @@ class TestBaseFlow(unittest.TestCase):
             'description': 'Run two tasks',
             'tasks': {
                 1: {'task': 'pass_name'},
-                2: {'task': 'name_response'},
+                2: {'task': 'name_response', 'options': {
+                    'response': '^^pass_name.name'
+                }},
             }
         })
 
@@ -184,6 +186,57 @@ class TestBaseFlow(unittest.TestCase):
 
         # the number of tasks in the flow should be 1 instead of 2
         self.assertEquals(1, len(flow.task_results))
+
+    def test_find_task_by_name_missing(self):
+        """ The _find_task_by_name method skips tasks that don't exist """
+
+        # instantiate a flow with two tasks
+        flow_config = FlowConfig({
+            'description': 'Run two tasks',
+            'tasks': {
+                1: {'task': 'pass_name'},
+                2: {'task': 'name_response', 'options': {
+                    'response': '^^pass_name.name'
+                }},
+            }
+        })
+
+        flow = BaseFlow(
+            self.project_config,
+            flow_config,
+            self.org_config,
+        )
+
+        self.assertEquals(None, flow._find_task_by_name('missing'))
+        self.assertEquals(None, flow._find_task_by_name('name_response'))
+
+    def test_find_task_by_name_not_first(self):
+        """ The _find_task_by_name method skips tasks that don't exist """
+
+        # instantiate a flow with two tasks
+        flow_config = FlowConfig({
+            'description': 'Run two tasks',
+            'tasks': {
+                1: {'task': 'pass_name'},
+                2: {'task': 'name_response', 'options': {
+                    'response': '^^pass_name.name'
+                }},
+            }
+        })
+
+        flow = BaseFlow(
+            self.project_config,
+            flow_config,
+            self.org_config,
+        )
+
+        flow()
+
+        task = flow._find_task_by_name('name_response')
+        self.assertEquals(
+            'cumulusci.core.tests.test_flows._TaskResponseName',
+            task.task_config.class_path,
+        )
 
     def test_call_no_tasks(self):
         """ A flow with no tasks will have no responses. """

--- a/cumulusci/core/tests/test_flows.py
+++ b/cumulusci/core/tests/test_flows.py
@@ -250,15 +250,15 @@ class TestBaseFlow(unittest.TestCase):
         )
 
     def test_render_task_config_empty_value(self):
-        """ The _find_task_by_name method skips tasks that don't exist """
+        """ The _render_task_config method skips option values of None """
 
         # instantiate a flow with two tasks
         flow_config = FlowConfig({
             'description': 'Run a tasks',
             'tasks': {
-                1: {'task': 'pass_name',
+                1: {'task': 'name_response',
                     'options': {
-                        'name': None,
+                        'response': None,
                     },
             
                    },
@@ -273,7 +273,7 @@ class TestBaseFlow(unittest.TestCase):
 
         flow()
 
-        task = flow._find_task_by_name('pass_name')
+        task = flow._find_task_by_name('name_response')
         config = flow._render_task_config(task)
         self.assertEquals(['Options:'], config)
 

--- a/cumulusci/core/tests/test_flows.py
+++ b/cumulusci/core/tests/test_flows.py
@@ -258,7 +258,7 @@ class TestBaseFlow(unittest.TestCase):
             'tasks': {
                 1: {'task': 'pass_name',
                     'options': {
-                        'response': None,
+                        'name': None,
                     },
             
                    },

--- a/cumulusci/core/tests/test_flows.py
+++ b/cumulusci/core/tests/test_flows.py
@@ -29,7 +29,6 @@ class _TaskResponseName(BaseTask):
     def _run_task(self):
         return self.options['response']
 
-
 class _SfdcTask(BaseTask):
     salesforce_task = True
 
@@ -110,6 +109,31 @@ class TestBaseFlow(unittest.TestCase):
         flow()
         # the flow results for the second task should be 'name'
         self.assertEquals('supername', flow.task_results[1])
+
+    def test_pass_task_options(self):
+        """ A flow can accept task options and pass them to the task. """
+
+        # instantiate a flow with two tasks
+        flow_config = FlowConfig({
+            'description': 'Run two tasks',
+            'tasks': {
+                1: {'task': 'name_response', 'options': {
+                    'response': 'foo'
+                }},
+            }
+        })
+
+        flow = BaseFlow(
+            self.project_config,
+            flow_config,
+            self.org_config,
+            options={'name_response__response': 'bar'},
+        )
+
+        # run the flow
+        flow()
+        # the flow results for the second task should be 'name'
+        self.assertEquals('bar', flow.task_results[0])
 
     def test_call_no_tasks(self):
         """ A flow with no tasks will have no responses. """

--- a/cumulusci/core/tests/test_flows.py
+++ b/cumulusci/core/tests/test_flows.py
@@ -238,6 +238,34 @@ class TestBaseFlow(unittest.TestCase):
             task.task_config.class_path,
         )
 
+    def test_render_task_config_empty_value(self):
+        """ The _find_task_by_name method skips tasks that don't exist """
+
+        # instantiate a flow with two tasks
+        flow_config = FlowConfig({
+            'description': 'Run a tasks',
+            'tasks': {
+                1: {'task': 'pass_name',
+                    'options': {
+                        'response': None,
+                    },
+            
+                   },
+            },
+        })
+
+        flow = BaseFlow(
+            self.project_config,
+            flow_config,
+            self.org_config,
+        )
+
+        flow()
+
+        task = flow._find_task_by_name('pass_name')
+        config = flow._render_task_config(task)
+        self.assertEquals(['Options:'], config)
+
     def test_call_no_tasks(self):
         """ A flow with no tasks will have no responses. """
         flow_config = FlowConfig({

--- a/cumulusci/core/tests/test_flows.py
+++ b/cumulusci/core/tests/test_flows.py
@@ -132,10 +132,10 @@ class TestBaseFlow(unittest.TestCase):
 
         # run the flow
         flow()
-        # the flow results for the second task should be 'name'
+        # the flow results for the first task should be 'bar'
         self.assertEquals('bar', flow.task_results[0])
 
-    def test_skip_task(self):
+    def test_skip_kwarg(self):
         """ A flow can receive during init a list of tasks to skip """
 
         # instantiate a flow with two tasks
@@ -143,9 +143,7 @@ class TestBaseFlow(unittest.TestCase):
             'description': 'Run two tasks',
             'tasks': {
                 1: {'task': 'pass_name'},
-                2: {'task': 'name_response', 'options': {
-                    'response': '^^pass_name.name'
-                }},
+                2: {'task': 'name_response'},
             }
         })
 
@@ -159,7 +157,32 @@ class TestBaseFlow(unittest.TestCase):
         # run the flow
         flow()
 
-        # the flow results for the second task should be 'name'
+        # the number of tasks in the flow should be 1 instead of 2
+        self.assertEquals(1, len(flow.task_results))
+
+    def test_skip_task_value_none(self):
+        """ A flow skips any tasks whose name is None to allow override via yaml """
+
+        # instantiate a flow with two tasks
+        flow_config = FlowConfig({
+            'description': 'Run two tasks',
+            'tasks': {
+                1: {'task': 'pass_name'},
+                2: {'task': 'None'},
+            }
+        })
+
+        flow = BaseFlow(
+            self.project_config,
+            flow_config,
+            self.org_config,
+            skip=['name_response'],
+        )
+
+        # run the flow
+        flow()
+
+        # the number of tasks in the flow should be 1 instead of 2
         self.assertEquals(1, len(flow.task_results))
 
     def test_call_no_tasks(self):


### PR DESCRIPTION
One thing I'm not happy about is that `test_task_raises_exception_fail` for some reason prints the traceback from the raised exception it's testing.  I'm not sure if that's worth trying to figure out now or if we just chalk it up to a cost of higher coverage for now.