### PR TITLE
Fix coveralls.io reporting from Heroku CI to properly report branch of build

### DIFF
--- a/heroku_ci.sh
+++ b/heroku_ci.sh
@@ -3,6 +3,6 @@
 
 git clone -b "$HEROKU_TEST_RUN_BRANCH" --single-branch https://github.com/SalesforceFoundation/CumulusCI 
 cd CumulusCI
-git checkout $HEROKU_TEST_RUN_COMMIT_VERSION
+git reset --hard $HEROKU_TEST_RUN_COMMIT_VERSION
 nosetests --with-tap --tap-stream --with-coverage --cover-package=cumulusci
 coveralls


### PR DESCRIPTION
Changed from using `git checkout` to `git reset` to reset the branch to the build commit.  This keeps the branch reference in the local git repo so coveralls can get the right branch in the report.