### PR TITLE
Allow for namespaced and non-namespaced scratch orgs in the same project

### DIFF
--- a/cumulusci/cli/cli.py
+++ b/cumulusci/cli/cli.py
@@ -539,6 +539,8 @@ def org_scratch(config, config_name, org_name, default, delete, devhub):
     if devhub:
         scratch_config['devhub'] = devhub
 
+    scratch_config['namespaced'] = scratch_config.get('namespaced', False)
+
     org_config = ScratchOrgConfig(scratch_config)
 
     config.keychain.set_org(org_name, org_config)

--- a/cumulusci/core/config.py
+++ b/cumulusci/core/config.py
@@ -802,11 +802,15 @@ class ScratchOrgConfig(OrgConfig):
         if self.devhub:
             devhub = ' --targetdevhubusername {}'.format(self.devhub)
 
+        namespaced = ''
+        if not self.namespaced:
+            namespaced = ' -n'
+
         # This feels a little dirty, but the use cases for extra args would mostly
         # work best with env vars
         extraargs = os.environ.get('SFDX_ORG_CREATE_ARGS', '')
-        command = 'sfdx force:org:create -f {}{} {}'.format(
-            self.config_file, devhub, extraargs)
+        command = 'sfdx force:org:create -f {}{}{} {}'.format(
+            self.config_file, devhub, namespaced, extraargs)
         self.logger.info(
             'Creating scratch org with command {}'.format(command))
         p = sarge.Command(command, stdout=sarge.Capture(buffer_size=-1))


### PR DESCRIPTION
Closes #441 by allowing projects to specify that certain scratch org configurations defined in cumulusci.yml should have the namespace applied.  The default still remains that all orgs are created without a namespace even if the sfdx-project.json has a namespace configured.  This is because in a full feature + beta test environment, you need orgs without the namespace applied to install a managed version.

Since most projects using CumulusCI were previously set up to not hard code namespaces in order to enable unmanaged feature builds, we keep this as the default behavior.  Individual projects could easily flip the default `dev` and `feature` orgs to use the namespace while other orgs remain non-namespaced with the following in their cumulusci.yml file:

```
orgs:
  scratch:
    dev:
      namespaced: True
    feature:
      namespaced: True
```