### PR TITLE
cci org scratch should use config_name for org name by default

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,12 @@
 History
 =======
 
+2.0.0-beta62 (2017-09-19)
+-------------------------
+
+* BREAKING CHANGE: The `cci org scratch` command has changed.  It used to be `cci org scratch <config_name> <org_name>` which often led most users to run the command `cci org scratch dev dev` which is redundant.  The new command format is `cci org scratch <config_name>` which will set the org name to the config name.  If you want to set a different name than the config name, you can do that with `cci org scratch <config_name> --org <org_name>`
+* `cci org connect` and `cci org scratch` will now prompt for overwrite confirmation before overwriting an existing keychain org.  The `--overwrite` option flag can be passed to bypass the prompt and force overwrite an existing org.
+
 2.0.0-beta61 (2017-09-12)
 -------------------------
 

--- a/docs/cookbook.rst
+++ b/docs/cookbook.rst
@@ -379,8 +379,8 @@ You'll first need to setup some prerequirements:
 * Your project's workspace-config.json should have `"EnableTokenEncryption": false`
 * Once encryption is disabled, authorize DX to your Environment Hub org
 * Your packaging org should be connected to your keychain already, verify with `cci org info packaging`
-* Run `cci org scratch dev feature` to create the configuration for the scratch org in your cci keychain.  You should be able to run `cci org info feature` to see the config.
-* Run `cci org scratch dev beta` to create the configuration for the scratch org in your cci keychain.  You should be able to run `cci org info beta` to see the config.
+* Run `cci org scratch dev` to create the configuration for the scratch org in your cci keychain.  You should be able to run `cci org info dev` to see the config.
+* Run `cci org scratch beta` to create the configuration for the scratch org in your cci keychain.  You should be able to run `cci org info beta` to see the config.
 
 Once your project is set up in CircleCI, add the following additional environment variables in addition to the ones listed above:
 


### PR DESCRIPTION
Closes #436 

This branch changes `cci org scratch` from `cci org scratch <config_name> <org_name>` to `cci org scratch <config_name>` or optionally `cci org scratch <config_name> --org <org_name>`.  The default org name for scratch orgs is the config name unless you optionally override the name.

One concern is that the previous command `cci org scratch dev <org_name>` will now throw a usage error.  I think that's acceptable as any CI builds should be using the EnvironmentProjectKeychain instead of calling `cci org scratch` themselves.  The usage will show how to use the command and we can announce the breaking change in release notes and other channels.

The other concern is if existing users already have an org name `dev` and call the `cci org scratch dev` command without the `--org <org_name>` option, their existing `dev` org would be overwritten in the keychain possibly without their knowing.  To address this, `cci org scratch` and `cci org connect` now prompt for overwrite confirmation before overwriting an org and support the `--overwrite` option flag to bypass the prompt in headless scripts.