### PR TITLE
Auto Detection of CI environments

### DIFF
--- a/cumulusci/cli/cli.py
+++ b/cumulusci/cli/cli.py
@@ -19,6 +19,7 @@ from cumulusci.core.config import TaskConfig
 from cumulusci.core.config import YamlGlobalConfig
 from cumulusci.core.config import YamlProjectConfig
 from cumulusci.core.exceptions import ApexTestException
+from cumulusci.core.exceptions import ConfigError
 from cumulusci.core.exceptions import FlowNotFoundError
 from cumulusci.core.exceptions import KeychainConnectedAppNotFound
 from cumulusci.core.exceptions import KeychainKeyNotFound
@@ -73,6 +74,8 @@ class CliConfig(object):
             pass
         except NotInProject as e:
             raise click.UsageError(e.message)
+        except ConfigError as e:
+            raise click.UsageError('Config Error: {}'.format(e.message))
 
     def _load_keychain(self):
         self.keychain_key = os.environ.get('CUMULUSCI_KEY')
@@ -86,6 +89,27 @@ class CliConfig(object):
                 self.project_config, self.keychain_key)
             self.project_config.set_keychain(self.keychain)
 
+def make_pass_instance_decorator(obj, ensure=False):
+    """Given an object type this creates a decorator that will work
+    similar to :func:`pass_obj` but instead of passing the object of the
+    current context, it will inject the passed object instance.
+
+    This generates a decorator that works roughly like this::
+        from functools import update_wrapper
+        def decorator(f):
+            @pass_context
+            def new_func(ctx, *args, **kwargs):
+                return ctx.invoke(f, obj, *args, **kwargs)
+            return update_wrapper(new_func, f)
+        return decorator
+    :param obj: the object instance to pass.
+    """
+    def decorator(f):
+        def new_func(*args, **kwargs):
+            ctx = click.get_current_context()
+            return ctx.invoke(f, obj, *args[1:], **kwargs)
+        return click.decorators.update_wrapper(new_func, f)
+    return decorator
 
 try:
     CLI_CONFIG = CliConfig()
@@ -93,9 +117,7 @@ except click.UsageError as e:
     click.echo(e.message)
     sys.exit(1)
 
-
-pass_config = click.make_pass_decorator(CliConfig, ensure=True)
-
+pass_config = make_pass_instance_decorator(CLI_CONFIG)
 
 def check_connected_app(config):
     check_keychain(config)


### PR DESCRIPTION
Fixes #451 by adding support for auto detecting CI system build environments via environment variables.  If a known CI environment is detected, its repository information will be injected into the project config instead of relying on parsing the files in the .git directory.

An initial implementation is included for Heroku CI which should allow Heroku CI to run cci builds easily.