### PR TITLE
cci org * enhancements

### DIFF
--- a/cumulusci/cli/cli.py
+++ b/cumulusci/cli/cli.py
@@ -56,11 +56,14 @@ def dbm_cache():
     context manager for accessing simple dbm cache
     located at ~/.cumlusci/cache.dbm
     """
-    db = dbm.open(os.path.join(
+    config_dir = os.path.join(
         os.path.expanduser('~'),
         YamlGlobalConfig.config_local_dir,
-        'cache.dbm'
-    ), 'c',)
+        
+    if not os.path.exists(config_dir):
+        os.mkdir(config_dir)
+
+    db = dbm.open(os.path.join(config_dir, 'cache.dbm'), 'c',)
     yield db
     db.close()
 

--- a/cumulusci/cli/cli.py
+++ b/cumulusci/cli/cli.py
@@ -604,8 +604,6 @@ def org_list(config):
         row.append('*' if org_config.scratch else '')
         row.append(org_config.config_name if org_config.config_name else '')
         username = org_config.config.get('username', org_config.userinfo__preferred_username)
-        if not username:
-            username = org_config.userinfo__preferred_username
         row.append(username if username else '')
         data.append(row)
     table = Table(data, headers)

--- a/cumulusci/cli/cli.py
+++ b/cumulusci/cli/cli.py
@@ -59,6 +59,7 @@ def dbm_cache():
     config_dir = os.path.join(
         os.path.expanduser('~'),
         YamlGlobalConfig.config_local_dir,
+    )
         
     if not os.path.exists(config_dir):
         os.mkdir(config_dir)

--- a/cumulusci/cli/cli.py
+++ b/cumulusci/cli/cli.py
@@ -34,6 +34,7 @@ from cumulusci.core.exceptions import ConfigError
 from cumulusci.core.exceptions import FlowNotFoundError
 from cumulusci.core.exceptions import KeychainConnectedAppNotFound
 from cumulusci.core.exceptions import KeychainKeyNotFound
+from cumulusci.core.exceptions import OrgNotFound
 from cumulusci.salesforce_api.exceptions import MetadataApiError
 from cumulusci.salesforce_api.exceptions import MetadataComponentFailure
 from cumulusci.core.exceptions import NotInProject
@@ -591,16 +592,32 @@ def org_info(config, org_name):
 def org_list(config):
     check_connected_app(config)
     data = []
-    headers = ['org', 'is_default']
+    headers = ['org', 'default', 'scratch', 'config_name', 'username']
     for org in config.project_config.list_orgs():
         org_config = config.project_config.get_org(org)
-        if org_config.default:
-            data.append((org, '*'))
-        else:
-            data.append((org, ''))
+        row = [org]
+        row.append('*' if org_config.default else '')
+        row.append('*' if org_config.scratch else '')
+        row.append(org_config.config_name if org_config.config_name else '')
+        username = org_config.config.get('username')
+        if not username:
+            username = org_config.userinfo__preferred_username
+        row.append(username if username else '')
+        data.append(row)
     table = Table(data, headers)
     click.echo(table)
 
+@click.command(name='remove', help="Removes an org from the keychain")
+@click.argument('org_name')
+@click.option('--global-org', is_flag=True, help="Set this option to force remove a global org.  Default behavior is to error if you attempt to delete a global org.")
+@pass_config
+def org_remove(config, org_name, global_org):
+    check_connected_app(config)
+    try:
+        org_config = config.keychain.get_org(org_name)
+    except OrgNotFound:
+        raise click.ClickException('Org {} does not exist in the keychain'.format(org_name))
+    config.keychain.remove_org(org_name, global_org)
 
 @click.command(name='scratch', help="Connects a Salesforce DX Scratch Org to the keychain")
 @click.argument('config_name')
@@ -625,11 +642,7 @@ def org_scratch(config, config_name, org_name, default, delete, devhub):
     if devhub:
         scratch_config['devhub'] = devhub
 
-    scratch_config['namespaced'] = scratch_config.get('namespaced', False)
-
-    org_config = ScratchOrgConfig(scratch_config)
-
-    config.keychain.set_org(org_name, org_config)
+    config.keychain.create_scratch_org(org_name, config_name, scratch_config)
 
     if default:
         org = config.keychain.set_default_org(org_name)
@@ -683,6 +696,7 @@ org.add_command(org_connected_app)
 org.add_command(org_default)
 org.add_command(org_info)
 org.add_command(org_list)
+org.add_command(org_remove)
 org.add_command(org_scratch)
 org.add_command(org_scratch_delete)
 

--- a/cumulusci/cli/cli.py
+++ b/cumulusci/cli/cli.py
@@ -603,7 +603,7 @@ def org_list(config):
         row.append('*' if org_config.default else '')
         row.append('*' if org_config.scratch else '')
         row.append(org_config.config_name if org_config.config_name else '')
-        username = org_config.config.get('username')
+        username = org_config.config.get('username', org_config.userinfo__preferred_username)
         if not username:
             username = org_config.userinfo__preferred_username
         row.append(username if username else '')

--- a/cumulusci/core/config.py
+++ b/cumulusci/core/config.py
@@ -941,11 +941,15 @@ class ScratchOrgConfig(OrgConfig):
         if not self.namespaced:
             namespaced = ' -n'
 
+        alias = ''
+        if self.sfdx_alias:
+            alias = ' -a "{}"'.format(self.sfdx_alias)
+
         # This feels a little dirty, but the use cases for extra args would mostly
         # work best with env vars
         extraargs = os.environ.get('SFDX_ORG_CREATE_ARGS', '')
-        command = 'sfdx force:org:create -f {}{}{} {}'.format(
-            self.config_file, devhub, namespaced, extraargs)
+        command = 'sfdx force:org:create -f {}{}{}{} {}'.format(
+            self.config_file, devhub, namespaced, alias, extraargs)
         self.logger.info(
             'Creating scratch org with command {}'.format(command))
         p = sarge.Command(command, stdout=sarge.Capture(buffer_size=-1))

--- a/cumulusci/core/keychain.py
+++ b/cumulusci/core/keychain.py
@@ -32,8 +32,42 @@ class BaseProjectKeychain(BaseConfig):
         self._load_keychain()
 
     def _load_keychain(self):
-        """ Subclasses can override to implement logic to load the keychain """
+        self._load_app()
+        self._load_orgs()
+        self._load_scratch_orgs()
+        self._load_services()
+
+    def _load_app(self):
         pass
+
+    def _load_orgs(self):
+        pass
+
+    def _load_scratch_orgs(self):
+        """ Creates all scratch org configs for the project in the keychain if
+            a keychain org doesn't already exist """
+        current_orgs = self.list_orgs()
+        if not self.project_config.orgs__scratch:
+            return
+        for org_name, scratch_config in self.project_config.orgs__scratch.items():
+            if org_name in current_orgs:
+                # Don't overwrite an existing keychain org
+                continue
+            self.create_scratch_org(org_name, org_name, scratch_config)
+
+    def _load_services(self):
+        pass
+            
+    def create_scratch_org(self, org_name, config_name, scratch_config):
+        """ Adds/Updates a scratch org config to the keychain from a named config """
+        scratch_config['namespaced'] = scratch_config.get('namespaced', False)
+        scratch_config['config_name'] = config_name
+        scratch_config['sfdx_alias'] = '{}__{}'.format(
+            self.project_config.project__name,
+            org_name,
+        )
+        org_config = ScratchOrgConfig(scratch_config)
+        self.set_org(org_name, org_config)
 
     def change_key(self, key):
         """ re-encrypt stored services, orgs, and the connected_app
@@ -65,7 +99,7 @@ class BaseProjectKeychain(BaseConfig):
         """ store a connected_app configuration """
 
         self._set_connected_app(app_config, project)
-        self._load_keychain()
+        self._load_app()
 
     def _set_connected_app(self, app_config, project):
         self.app = app_config
@@ -78,11 +112,19 @@ class BaseProjectKeychain(BaseConfig):
     def _get_connected_app(self):
         return self.app
 
+    def remove_org(self, name, global_org=None):
+        if name in self.orgs.keys():
+            self._remove_org(name, global_org)
+
+    def _remove_org(self, name, global_org):
+        del self.orgs[name]
+        self._load_orgs()
+
     def set_org(self, name, org_config, global_org=False):
         if isinstance(org_config, ScratchOrgConfig):
             org_config.config['scratch'] = True
         self._set_org(name, org_config, global_org)
-        self._load_keychain()
+        self._load_orgs()
 
     def _set_org(self, name, org_config, global_org):
         self.orgs[name] = org_config
@@ -135,7 +177,7 @@ class BaseProjectKeychain(BaseConfig):
             self._raise_service_not_valid(name)
         self._validate_service(name, service_config)
         self._set_service(name, service_config, project)
-        self._load_keychain()
+        self._load_services()
 
     def _set_service(self, name, service_config, project):
         self.services[name] = service_config
@@ -192,17 +234,12 @@ class EnvironmentProjectKeychain(BaseProjectKeychain):
     app_var = 'CUMULUSCI_CONNECTED_APP'
     service_var_prefix = 'CUMULUSCI_SERVICE_'
 
-    def _load_keychain(self):
-        self._load_keychain_app()
-        self._load_keychain_orgs()
-        self._load_keychain_services()
-
-    def _load_keychain_app(self):
+    def _load_app(self):
         app = os.environ.get(self.app_var)
         if app:
             self.app = ConnectedAppOAuthConfig(json.loads(app))
 
-    def _load_keychain_orgs(self):
+    def _load_orgs(self):
         for key, value in os.environ.items():
             if key.startswith(self.org_var_prefix):
                 org_config = json.loads(value)
@@ -213,7 +250,7 @@ class EnvironmentProjectKeychain(BaseProjectKeychain):
                     self.orgs[key[len(self.org_var_prefix):]
                               ] = OrgConfig(json.loads(value))
 
-    def _load_keychain_services(self):
+    def _load_services(self):
         for key, value in os.environ.items():
             if key.startswith(self.service_var_prefix):
                 self.services[key[len(self.service_var_prefix):]] = ServiceConfig(
@@ -301,27 +338,49 @@ class EncryptedFileProjectKeychain(BaseEncryptedProjectKeychain):
     def project_local_dir(self):
         return self.project_config.project_local_dir
 
-    def _load_keychain(self):
+    def _load_files(self, dirname, extension, key):
+        for item in os.listdir(dirname):
+            if item.endswith(extension):
+                with open(os.path.join(dirname, item), 'r') as f_item:
+                    config = f_item.read()
+                name = item.replace(extension, '')
+                if not key in self.config:
+                    self.config[key] = []
+                self.config[key][name] = config
 
-        def load_files(dirname):
-            for item in os.listdir(dirname):
-                if item.endswith('.org'):
-                    with open(os.path.join(dirname, item), 'r') as f_item:
-                        org_config = f_item.read()
-                    org_name = item.replace('.org', '')
-                    self.config['orgs'][org_name] = org_config
-                elif item.endswith('.service'):
-                    with open(os.path.join(dirname, item), 'r') as f_item:
-                        service_config = f_item.read()
-                    service_name = item.replace('.service', '')
-                    self.config['services'][service_name] = service_config
-                elif item == 'connected.app':
-                    with open(os.path.join(dirname, item), 'r') as f_item:
-                        app_config = f_item.read()
-                    self.config['app'] = app_config
+    def _load_file(self, dirname, filename, key):
+        full_path = os.path.join(dirname, filename)
+        if not os.path.exists(full_path):
+            return
+        with open(os.path.join(dirname, filename), 'r') as f_item:
+            config = f_item.read()
+        self.config[key] = config
 
-        load_files(self.config_local_dir)
-        load_files(self.project_local_dir)
+    def _load_app(self):
+        self._load_file(self.config_local_dir, 'connected.app', 'app')
+        self._load_file(self.project_local_dir, 'connected.app', 'app')
+
+    def _load_orgs(self):
+        self._load_files(self.config_local_dir, '.org', 'orgs')
+        self._load_files(self.project_local_dir, '.org', 'orgs')
+
+    def _load_services(self):
+        self._load_files(self.config_local_dir, '.service', 'services')
+        self._load_files(self.project_local_dir, '.service', 'services')
+
+    def _remove_org(self, name, global_org):
+        if global_org:
+            full_path = os.path.join(self.config_local_dir, '{}.org'.format(name))
+        else:
+            full_path = os.path.join(self.project_local_dir, '{}.org'.format(name))
+        if not os.path.exists(full_path):
+            kwargs = {'name': name}
+            if not global_org:
+                raise OrgNotFound('Could not find org named {name} to delete.  Deleting in project org mode.  Is {name} a global org?'.format(**kwargs))
+            raise OrgNotFound('Could not find org named {name} to delete.  Deleting in global org mode.  Is {name} a project org instead of a global org?'.format(**kwargs))
+           
+        os.remove(full_path) 
+        self._load_orgs()
 
     def _set_encrypted_connected_app(self, encrypted, project):
         if project:

--- a/cumulusci/core/tests/test_keychain.py
+++ b/cumulusci/core/tests/test_keychain.py
@@ -176,6 +176,36 @@ class TestBaseProjectKeychain(unittest.TestCase):
             ScratchOrgConfig,
         )
 
+    def test_load_scratch_orgs_none(self):
+        self._test_load_scratch_orgs_none()
+
+    def _test_load_scratch_orgs_none(self):
+        keychain = self.keychain_class(self.project_config, self.key)
+        self.assertEquals(keychain.orgs.keys(), [])
+
+    def test_load_scratch_orgs_create_one(self):
+        self._test_load_scratch_orgs_create_one()
+
+    def _test_load_scratch_orgs_create_one(self):
+        self.project_config.config['orgs'] = {}
+        self.project_config.config['orgs']['scratch'] = {}
+        self.project_config.config['orgs']['scratch']['test_scratch_auto'] = {}
+        keychain = self.keychain_class(self.project_config, self.key)
+        self.assertEquals(keychain.orgs.keys(), ['test_scratch_auto'])
+
+    def test_load_scratch_orgs_existing_org(self):
+        self._test_load_scratch_orgs_existing_org()
+
+    def _test_load_scratch_orgs_existing_org(self):
+        self.project_config.config['orgs'] = {}
+        self.project_config.config['orgs']['scratch'] = {}
+        self.project_config.config['orgs']['scratch']['test'] = {}
+        keychain = self.keychain_class(self.project_config, self.key)
+        keychain.set_org('test', OrgConfig())
+        self.assertEquals(keychain.orgs.keys(), ['test'])
+        org = keychain.get_org('test')
+        self.assertEquals(org.scratch, None)
+
     def test_get_org_not_found(self):
         self._test_get_org_not_found()
 
@@ -316,6 +346,24 @@ class TestEnvironmentProjectKeychain(TestBaseProjectKeychain):
             keychain = self.keychain_class(self.project_config, self.key)
             self.assertEquals(keychain.list_orgs(), ['test'])
             self.assertEquals(keychain.orgs['test'].__class__, ScratchOrgConfig)
+
+    def test_load_scratch_orgs_none(self):
+        with EnvironmentVarGuard() as env:
+            self._clean_env(env)
+            env.set(
+                self.keychain_class.app_var,
+                json.dumps(self.connected_app_config.config)
+            )
+            self._test_load_scratch_orgs_none()
+
+    def test_load_scratch_orgs_create_one(self):
+        with EnvironmentVarGuard() as env:
+            self._clean_env(env)
+            env.set(
+                self.keychain_class.app_var,
+                json.dumps(self.connected_app_config.config)
+            )
+            self._test_load_scratch_orgs_create_one()
 
     def test_get_org_not_found(self):
         with EnvironmentVarGuard() as env:
@@ -534,6 +582,27 @@ class TestEncryptedFileProjectKeychain(TestBaseProjectKeychain):
         mock_class.return_value = self.tempdir_home
         os.chdir(self.tempdir_project)
         self._test_set_and_get_scratch_org()
+
+    def test_load_scratch_orgs_none(self, mock_class):
+        self._mk_temp_home()
+        self._mk_temp_project()
+        mock_class.return_value = self.tempdir_home
+        os.chdir(self.tempdir_project)
+        self._test_load_scratch_orgs_none()
+
+    def test_load_scratch_orgs_create_one(self, mock_class):
+        self._mk_temp_home()
+        self._mk_temp_project()
+        mock_class.return_value = self.tempdir_home
+        os.chdir(self.tempdir_project)
+        self._test_load_scratch_orgs_create_one()
+
+    def test_load_scratch_orgs_existing_org(self, mock_class):
+        self._mk_temp_home()
+        self._mk_temp_project()
+        mock_class.return_value = self.tempdir_home
+        os.chdir(self.tempdir_project)
+        self._test_load_scratch_orgs_existing_org()
 
     def test_set_and_get_org_global(self, mock_class):
         self._mk_temp_home()

--- a/heroku_ci.sh
+++ b/heroku_ci.sh
@@ -57,7 +57,7 @@ if [ "$HEROKU_TEST_RUN_BRANCH" == "master" ] ||\
 
     # Run ci_feature
     coverage run --append --source=../cumulusci `which cci` flow run ci_feature --org scratch --delete-org | tee cci.log
-    exit_status=$?
+    exit_status=${PIPESTATUS[0]}
     if [ "$exit_status" == "0" ]; then
         echo "ok 1 - Successfully ran ci_feature"
     else
@@ -67,7 +67,7 @@ if [ "$HEROKU_TEST_RUN_BRANCH" == "master" ] ||\
         
     # Run ci_beta
     coverage run --append --source=../cumulusci `which cci` flow run ci_beta --org scratch --delete-org | tee -a cci.log
-    exit_status=$?
+    exit_status=${PIPESTATUS[0]}
     if [ "$exit_status" == "0" ]; then
         echo "ok 4 - Successfully ran ci_beta"
     else
@@ -77,7 +77,7 @@ if [ "$HEROKU_TEST_RUN_BRANCH" == "master" ] ||\
 
     # Run ci_master
     coverage run --append --source=../cumulusci `which cci` flow run ci_master --org packaging | tee -a cci.log
-    exit_status=$?
+    exit_status=${PIPESTATUS[0]}
     if [ "$exit_status" == "0" ]; then
         echo "ok 2 - Successfully ran ci_master"
     else
@@ -87,7 +87,7 @@ if [ "$HEROKU_TEST_RUN_BRANCH" == "master" ] ||\
 
     # Run release_beta
     coverage run --append --source=../cumulusci `which cci` flow run release_beta --org packaging | tee -a cci.log
-    exit_status=$?
+    exit_status=${PIPESTATUS[0]}
     if [ "$exit_status" == "0" ]; then
         echo "ok 3 - Successfully ran release_beta"
     else


### PR DESCRIPTION
Fixes #474 
Fixes #475 
Fixes #313 

This branch implements a few enhancements to the workflow of using the `cci org` grouping of commands.  More detail is available in the linked issues above but a quick summary:

* `cci org remove` now exists to remove an org from the keychain
* CumulusCI now sets an alias in sfdx for all created scratch orgs using the naming format `ProjectName__orgname`
* Named scratch org configs are now automatically created in the keychain.  If an org with the same name already exists, the existing org is not changed.  CumulusCI includes 4 by default and projects can define their own.


