### PR TITLE
Configure for beta66 bug fix release

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,12 @@
 History
 =======
 
+2.0.0-beta66 (2017-10-20)
+-------------------------
+
+* Configure `namespace_inject` for `deploy_post`
+* Fix the `--debug` flag on `cci task run` and `cci flow run` to allow debugging of exceptions which are caught by the CLI such as MetadataApiError, MetadataComponentError, etc.
+
 2.0.0-beta65 (2017-10-18)
 -------------------------
 

--- a/cumulusci/__init__.py
+++ b/cumulusci/__init__.py
@@ -1,4 +1,4 @@
 import os
 __import__('pkg_resources').declare_namespace('cumulusci')
-__version__ = '2.0.0-beta65'
+__version__ = '2.0.0-beta66'
 __location__ = os.path.dirname(os.path.realpath(__file__))

--- a/cumulusci/cli/cli.py
+++ b/cumulusci/cli/cli.py
@@ -106,6 +106,19 @@ def pretty_dict(data):
         return ''
     return json.dumps(data, sort_keys=True, indent=4, separators=(',', ': '))
 
+def handle_exception_debug(config, debug, e, throw_exception=None, no_prompt=None):
+    if debug:
+        import pdb
+        import traceback
+        traceback.print_exc()
+        pdb.post_mortem()
+    else:
+        if throw_exception:
+            raise throw_exception
+        else:
+            handle_sentry_event(config, no_prompt)
+            raise
+
 
 class CliConfig(object):
 
@@ -800,15 +813,9 @@ def task_run(config, task_name, org, o, debug, debug_before, debug_after, no_pro
             'This task requires a salesforce org.  Use org default <name> to set a default org or pass the org name with the --org option')
     except TaskOptionsError as e:
         exception = click.UsageError(e.message)
+        handle_exception_debug(config, debug, e, throw_exception=exception)
     except Exception as e:
-        if debug:
-            import pdb
-            import traceback
-            traceback.print_exc()
-            pdb.post_mortem()
-        else:
-            handle_sentry_event(config, no_prompt)
-            raise
+        handle_exception_debug(config, debug, e, no_prompt=no_prompt)
 
     if debug_before:
         import pdb
@@ -819,27 +826,27 @@ def task_run(config, task_name, org, o, debug, debug_before, debug_after, no_pro
             task()
         except TaskOptionsError as e:
             exception = click.UsageError(e.message)
+            handle_exception_debug(config, debug, e, throw_exception=exception)
         except ApexTestException as e:
             exception = click.ClickException('Failed: ApexTestFailure')
+            handle_exception_debug(config, debug, e, throw_exception=exception)
         except BrowserTestFailure as e:
             exception = click.ClickException('Failed: BrowserTestFailure')
+            handle_exception_debug(config, debug, e, throw_exception=exception)
         except MetadataComponentFailure as e:
             exception = click.ClickException(
-                'Failed: MetadataComponentFailure')
+                'Failed: MetadataComponentFailure'
+            )
+            handle_exception_debug(config, debug, e, throw_exception=exception)
         except MetadataApiError as e:
             exception = click.ClickException('Failed: MetadataApiError')
+            handle_exception_debug(config, debug, e, throw_exception=exception)
         except ScratchOrgException as e:
             exception = click.ClickException(
                 'ScratchOrgException: {}'.format(e.message))
+            handle_exception_debug(config, debug, e, throw_exception=exception)
         except Exception as e:
-            if debug:
-                import pdb
-                import traceback
-                traceback.print_exc()
-                pdb.post_mortem()
-            else:
-                handle_sentry_event(config, no_prompt)
-                raise
+            handle_exception_debug(config, debug, e, no_prompt=no_prompt)
 
     # Save the org config in case it was modified in the task
     if org and org_config:
@@ -941,14 +948,9 @@ def flow_run(config, flow_name, org, delete_org, debug, o, skip, no_prompt):
             'This flow requires a salesforce org.  Use org default <name> to set a default org or pass the org name with the --org option')
     except TaskOptionsError as e:
         exception = click.UsageError(e.message)
+        handle_exception_debug(config, debug, e, throw_exception=exception)
     except Exception as e:
-        if debug:
-            import pdb
-            import traceback
-            traceback.print_exc()
-            pdb.post_mortem()
-        else:
-            raise
+        handle_exception_debug(config, debug, e, no_prompt=no_prompt)
 
     if not exception:
         # Run the flow and handle exceptions
@@ -956,27 +958,28 @@ def flow_run(config, flow_name, org, delete_org, debug, o, skip, no_prompt):
             flow()
         except TaskOptionsError as e:
             exception = click.UsageError(e.message)
+            handle_exception_debug(config, debug, e, throw_exception=exception)
         except ApexTestException as e:
             exception = click.ClickException('Failed: ApexTestException')
+            handle_exception_debug(config, debug, e, throw_exception=exception)
         except BrowserTestFailure as e:
             exception = click.ClickException('Failed: BrowserTestFailure')
+            handle_exception_debug(config, debug, e, throw_exception=exception)
         except MetadataComponentFailure as e:
             exception = click.ClickException(
-                'Failed: MetadataComponentFailure')
+                'Failed: MetadataComponentFailure'
+            )
+            handle_exception_debug(config, debug, e, throw_exception=exception)
         except MetadataApiError as e:
             exception = click.ClickException('Failed: MetadataApiError')
+            handle_exception_debug(config, debug, e, throw_exception=exception)
         except ScratchOrgException as e:
             exception = click.ClickException(
-                'ScratchOrgException: {}'.format(e.message))
+                'ScratchOrgException: {}'.format(e.message)
+            )
+            handle_exception_debug(config, debug, e, throw_exception=exception)
         except Exception as e:
-            if debug:
-                import pdb
-                import traceback
-                traceback.print_exc()
-                pdb.post_mortem()
-            else:
-                handle_sentry_event(config, no_prompt)
-                raise
+            handle_exception_debug(config, debug, e, no_prompt=no_prompt)
 
     # Delete the scratch org if --delete-org was set
     if delete_org:

--- a/cumulusci/cumulusci.yml
+++ b/cumulusci/cumulusci.yml
@@ -45,6 +45,7 @@ tasks:
         options:
             path: unpackaged/post
             unmanaged: True
+            namespace_inject: $project_config.project__package__namespace
             namespace_token: '%%%NAMESPACE%%%'
             filename_token: '___NAMESPACE___'
     deploy_post_managed:

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,7 +2,7 @@
 build-base=pybuild
 
 [bumpversion]
-current_version = 2.0.0-beta65
+current_version = 2.0.0-beta66
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ test_requirements = [
 
 setup(
     name='cumulusci',
-    version='2.0.0-beta65',
+    version='2.0.0-beta66',
     description="Build and release tools for Salesforce developers",
     long_description=readme + '\n\n' + history,
     author="Jason Lantz",


### PR DESCRIPTION
* There was an issue introduced in beta65 with the filename token `___NAMESPACE___` used for injecting the namespace prefix into deploys.  The issue was caused by the change from `DeployNamespacedBundles` to `DeployBundles` which now requires the `namespace_inject` option to be set for namespace injection to be enabled.  This release fixes the issue by setting the `namespace_inject` option to `$project_config.project__package__namespace` which will look up the project's namespace and inject it as the option value.
* As part of debugging this issue, I realized that the exceptions we were handling in `cci` to throw nicer exceptions were being excluded from handling via the `--debug` flag.  This branch abstracts out the `--debug` flag logic so it can be applied to all exceptions for easier debugging.
* Configures for beta66 release