### PR TITLE
Configure default namespace_inject on deploy_post_managed

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,11 @@
 History
 =======
 
+2.0.0-beta68 (2017-10-20)
+-------------------------
+
+* Configure `namespace_inject` for `deploy_post_managed`
+
 2.0.0-beta67 (2017-10-20)
 -------------------------
 

--- a/cumulusci/__init__.py
+++ b/cumulusci/__init__.py
@@ -1,4 +1,4 @@
 import os
 __import__('pkg_resources').declare_namespace('cumulusci')
-__version__ = '2.0.0-beta67'
+__version__ = '2.0.0-beta68'
 __location__ = os.path.dirname(os.path.realpath(__file__))

--- a/cumulusci/cumulusci.yml
+++ b/cumulusci/cumulusci.yml
@@ -54,6 +54,7 @@ tasks:
         options:
             path: unpackaged/post
             unmanaged: False
+            namespace_inject: $project_config.project__package__namespace
             namespace_token: '%%%NAMESPACE%%%'
             filename_token: '___NAMESPACE___'
     execute_anon:

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,7 +2,7 @@
 build-base=pybuild
 
 [bumpversion]
-current_version = 2.0.0-beta67
+current_version = 2.0.0-beta68
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ test_requirements = [
 
 setup(
     name='cumulusci',
-    version='2.0.0-beta67',
+    version='2.0.0-beta68',
     description="Build and release tools for Salesforce developers",
     long_description=readme + '\n\n' + history,
     author="Jason Lantz",


### PR DESCRIPTION
deploy_post_managed was causing an error in the ci_beta flow because it wasn't running token replacement.  The cause was that namespace_inject wasn't set.  This branch simply sets a defualt value of the project's namespace in the core cumulusci.yml file.