### PR TITLE
scratch org creation error as constant for usage by metaci

### DIFF
--- a/cumulusci/core/config.py
+++ b/cumulusci/core/config.py
@@ -37,6 +37,9 @@ from cumulusci.oauth.salesforce import SalesforceOAuth2
 
 __location__ = os.path.dirname(os.path.realpath(__file__))
 
+# constants used by MetaCI
+FAILED_TO_CREATE_SCRATCH_ORG = 'Failed to create scratch org'
+
 
 class BaseConfig(object):
     """ Base class for all configuration objects """
@@ -970,8 +973,10 @@ class ScratchOrgConfig(OrgConfig):
             self.logger.info(line)
 
         if p.returncode:
-            message = 'Failed to create scratch org: \n{}'.format(
-                ''.join(stdout))
+            message = '{}: \n{}'.format(
+                FAILED_TO_CREATE_SCRATCH_ORG,
+                ''.join(stdout),
+            )
             raise ScratchOrgException(message)
 
         self.generate_password()


### PR DESCRIPTION
For the purposes of https://github.com/SalesforceFoundation/mrbelvedereci/issues/104

Looking for the error message when scratch org fails to create, I didn't want to just copy the string, so I have it here as a constant that is imported into the mrbelvedereci code.