### PR TITLE
update utils.py to use bytesio

### DIFF
--- a/cumulusci/utils.py
+++ b/cumulusci/utils.py
@@ -95,7 +95,7 @@ def removeXmlElement(name, directory, file_pattern, logger=None):
 
 def download_extract_zip(url, target=None, subfolder=None):
     resp = requests.get(url)
-    zip_content = io.StringIO(resp.content)
+    zip_content = io.BytesIO(resp.content)
     zip_file = zipfile.ZipFile(zip_content)
     if subfolder:
         zip_file = zip_subfolder(zip_file, subfolder)


### PR DESCRIPTION
refactor of utils.py previously switched to using BytesIO instead of StringIO for zip files, since they are indeed binary files. missed one instance.

utils imports `io` with the `future` standard librry overrides, which meant that StringIO is more stringently checking its types, causing this method to throw a TypeError