### PR TITLE
use unicode literals in metadata API file

### DIFF
--- a/cumulusci/salesforce_api/metadata.py
+++ b/cumulusci/salesforce_api/metadata.py
@@ -9,6 +9,7 @@ based on mrbelvedere/mpinstaller/mdapi.py
 #   - use format() instead of %
 #   - look at https://github.com/rholder/retrying
 
+from __future__ import unicode_literals
 import base64
 # import dateutil.parser
 import httplib


### PR DESCRIPTION
cci was crashing when decoding \u2019 from the SF API response (seems there by mistake). Using unicode literals from future fixes the crash.