### PR TITLE
Get QA org ids from MetaCI

### DIFF
--- a/cumulusci/cumulusci.yml
+++ b/cumulusci/cumulusci.yml
@@ -66,6 +66,9 @@ tasks:
     get_installed_packages:
         description: Retrieves a list of the currently installed managed package namespaces and their versions
         class_path: cumulusci.tasks.salesforce.GetInstalledPackages
+    get_org_list:
+        description: Get a list of registered QA orgs from MetaCI
+        class_path: cumulusci.tasks.metaci.GetOrgsFromMetaCI
     github_clone_tag:
         description: Lists open pull requests in project Github repository
         class_path: cumulusci.tasks.github.CloneTag

--- a/cumulusci/tasks/metaci.py
+++ b/cumulusci/tasks/metaci.py
@@ -1,0 +1,52 @@
+import coreapi
+from cumulusci.core.tasks import BaseTask
+from cumulusci.core.exceptions import ServiceNotConfigured
+
+class ApiClient(object):
+    def __init__(self, config):
+        self.service = config.keychain.get_service('metaci')            
+           
+        auth = coreapi.auth.TokenAuthentication(self.service.token, scheme='Token')
+        self.client = coreapi.Client(auth=auth)
+        self._load_document()
+
+    def _load_document(self):
+        self.document = self.client.get(self.service.url + '/api/schema')
+    
+    def __call__(self, *args, **kwargs):
+        """ A shortcut to allow api_client('action') instead of api_client.client.action(self.document, 'action') """
+        resp = self.client.action(self.document, args, **kwargs)
+        return resp
+
+
+class BaseMetaCITask(BaseTask):
+    def _update_credentials(self):
+        self.api = ApiClient(self.project_config)
+
+class GetOrgsFromMetaCI(BaseMetaCITask):
+    task_options = {
+        'repo_id': {
+            'description': 'The MetaCI Repo ID',
+            'required': True,
+        },
+        'output_file': {
+            'description': 'The file to write out to.',
+            'required': False
+        },
+    }
+
+    def _run_task(self):
+        orgs = self.api('registered_orgs','list',params={'repo':self.options['repo_id']})['results']
+        org_ids = []
+        if orgs:
+            for org in orgs:
+                self.logger.info('{}: {} - {}'.format(org['org_id'], org['name'], org['release_cycle']))
+                if org['release_cycle'] == 'QA':
+                    org_ids.append(org['org_id'] + "\n")
+
+        if 'output_file' in self.options:
+            with open(self.options['output_file'],'w') as f:
+                f.writelines(org_ids)
+        
+
+        

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,3 +21,4 @@ PyYAML==3.11
 SQLAlchemy==1.1.4
 arrow==0.10.0
 future==0.16.0
+coreapi


### PR DESCRIPTION
requires the MetaCI OrgMart PR to merge.

usage (for cumulus) is
```
cci service connect metaci
cci task run get_org_list -o repo_id 4 -o output_file qa_push.txt
cat qa_push.txt
```

Very barebones because I don't actually know what you need or want in your qa push flow, chris. but. here's a start!