### PR TITLE
 Add support for setting durationdays on scratch orgs and tracking org expiration

### DIFF
--- a/cumulusci/cli/cli.py
+++ b/cumulusci/cli/cli.py
@@ -113,7 +113,6 @@ def check_org_expired(config, org_name, org_config):
             config.keychain.create_scratch_org(
                 org_name,
                 org_config.config_name,
-                {'namespaced': org_config.namespaced},
                 org_config.days,
             )
             click.echo('Org config was refreshed, attempting to recreate scratch org')

--- a/cumulusci/cli/cli.py
+++ b/cumulusci/cli/cli.py
@@ -116,8 +116,8 @@ def check_org_expired(config, org_name, org_config):
                 org_config.days,
             )
             click.echo('Org config was refreshed, attempting to recreate scratch org')
-            org = config.keychain.get_org(org_name)
-            org.create_org()
+            org_config = config.keychain.get_org(org_name)
+            org_config.create_org()
         else:
             raise click.ClickException('The target scratch org is expired.  You can use cci org remove {} to remove the org and then recreate the config manually'.format(org_name))
 

--- a/cumulusci/cli/cli.py
+++ b/cumulusci/cli/cli.py
@@ -744,7 +744,7 @@ def org_scratch(config, config_name, org_name, default, delete, devhub, days):
     if devhub:
         scratch_config['devhub'] = devhub
 
-    config.keychain.create_scratch_org(org_name, config_name, scratch_config, days)
+    config.keychain.create_scratch_org(org_name, config_name, days)
 
     if default:
         org = config.keychain.set_default_org(org_name)

--- a/cumulusci/cli/cli.py
+++ b/cumulusci/cli/cli.py
@@ -107,22 +107,20 @@ def check_latest_version():
                 "An update to CumulusCI is available. Use pip install --upgrade cumulusci to update.")
 
 def check_org_expired(config, org_name, org_config):
-    if org_config.scratch and org_config.expires and org_config.expired:
+    if org_config.scratch and org_config.date_created and org_config.expired:
         click.echo(click.style('The scratch org is expired', fg='yellow'))
         if click.confirm('Attempt to recreate the scratch org?', default=True):
-            config.keychain.set_org(
+            config.keychain.create_scratch_org(
                 org_name,
-                config.keychain.create_scratch_org(
-                    org_name,
-                    org_config.config_name,
-                    {'namespaced': org_config.namespaced},
-                    org_config.days,
-                )
+                org_config.config_name,
+                {'namespaced': org_config.namespaced},
+                org_config.days,
             )
-            click.echo('Org config was refreshed and should be ready to create a new scratch org')
-            return config.keychain.get_org(org_name)
+            click.echo('Org config was refreshed, attempting to recreate scratch org')
+            org = config.keychain.get_org(org_name)
+            org.create_org()
         else:
-            raise click.ClickException('The target scratch org is expired.  You can use cci org remove {} to remove the org and then recreate the config manually'.format(org.name))
+            raise click.ClickException('The target scratch org is expired.  You can use cci org remove {} to remove the org and then recreate the config manually'.format(org_name))
 
     return org_config
 

--- a/cumulusci/cli/cli.py
+++ b/cumulusci/cli/cli.py
@@ -106,6 +106,26 @@ def check_latest_version():
             click.echo(
                 "An update to CumulusCI is available. Use pip install --upgrade cumulusci to update.")
 
+def check_org_expired(config, org_name, org_config):
+    if org_config.scratch and org_config.expires and org_config.expired:
+        click.echo(click.style('The scratch org is expired', fg='yellow'))
+        if click.confirm('Attempt to recreate the scratch org?', default=True):
+            config.keychain.set_org(
+                org_name,
+                config.keychain.create_scratch_org(
+                    org_name,
+                    org_config.config_name,
+                    {'namespaced': org_config.namespaced},
+                    org_config.days,
+                )
+            )
+            click.echo('Org config was refreshed and should be ready to create a new scratch org')
+            return config.keychain.get_org(org_name)
+        else:
+            raise click.ClickException('The target scratch org is expired.  You can use cci org remove {} to remove the org and then recreate the config manually'.format(org.name))
+
+    return org_config
+
 def handle_exception_debug(config, debug, e, throw_exception=None, no_prompt=None):
     if debug:
         import pdb
@@ -584,6 +604,7 @@ def org_browser(config, org_name):
     check_connected_app(config)
 
     org_config = config.project_config.get_org(org_name)
+    org_config = check_org_expired(config, org_name, org_config)
     org_config.refresh_oauth_token(config.keychain.get_connected_app())
 
     webbrowser.open(org_config.start_url)
@@ -648,6 +669,7 @@ def org_info(config, org_name, print_json):
     check_connected_app(config)
 
     org_config = config.keychain.get_org(org_name)
+    org_config = check_org_expired(config, org_name, org_config)
 
     try:
         org_config.refresh_oauth_token(config.keychain.get_connected_app())
@@ -659,6 +681,9 @@ def org_info(config, org_name, print_json):
     else:
         click.echo(render_recursive(org_config.config))
 
+    if org_config.scratch and org_config.expires:
+        click.echo('Org expires on {}'.format(org_config.expires.strftime('%c')))
+        
     # Save the org config in case it was modified
     config.keychain.set_org(org_name, org_config)
 
@@ -668,12 +693,17 @@ def org_info(config, org_name, print_json):
 def org_list(config):
     check_connected_app(config)
     data = []
-    headers = ['org', 'default', 'scratch', 'config_name', 'username']
+    headers = ['org', 'default', 'scratch', 'days', 'expired', 'config_name', 'username']
     for org in config.project_config.list_orgs():
         org_config = config.project_config.get_org(org)
         row = [org]
         row.append('*' if org_config.default else '')
         row.append('*' if org_config.scratch else '')
+        if org_config.days_alive:
+            row.append('{} of {}'.format(org_config.days_alive, org_config.days) if org_config.scratch else '')
+        else:
+            row.append(org_config.days if org_config.scratch else '')
+        row.append('*' if org_config.scratch and org_config.expired else '')
         row.append(org_config.config_name if org_config.config_name else '')
         username = org_config.config.get('username', org_config.userinfo__preferred_username)
         row.append(username if username else '')
@@ -699,8 +729,9 @@ def org_remove(config, org_name, global_org):
 @click.option('--default', is_flag=True, help='If set, sets the connected org as the new default org')
 @click.option('--delete', is_flag=True, help="If set, triggers a deletion of the current scratch org.  This can be used to reset the org as the org configuration remains to regenerate the org on the next task run.")
 @click.option('--devhub', help="If provided, overrides the devhub used to create the scratch org")
+@click.option('--days', help="If provided, overrides the scratch config default days value for how many days the scratch org should persist")
 @pass_config
-def org_scratch(config, config_name, org_name, default, delete, devhub):
+def org_scratch(config, config_name, org_name, default, delete, devhub, days):
     check_connected_app(config)
 
     scratch_configs = getattr(config.project_config, 'orgs__scratch')
@@ -716,7 +747,7 @@ def org_scratch(config, config_name, org_name, default, delete, devhub):
     if devhub:
         scratch_config['devhub'] = devhub
 
-    config.keychain.create_scratch_org(org_name, config_name, scratch_config)
+    config.keychain.create_scratch_org(org_name, config_name, scratch_config, days)
 
     if default:
         org = config.keychain.set_default_org(org_name)
@@ -832,6 +863,7 @@ def task_run(config, task_name, org, o, debug, debug_before, debug_after, no_pro
         org_config = config.project_config.get_org(org)
     else:
         org, org_config = config.project_config.keychain.get_default_org()
+    org_config = check_org_expired(config, org, org_config)
     task_config = getattr(config.project_config, 'tasks__{}'.format(task_name))
     if not task_config:
         raise TaskNotFoundError('Task not found: {}'.format(task_name))
@@ -973,6 +1005,8 @@ def flow_run(config, flow_name, org, delete_org, debug, o, skip, no_prompt):
     else:
         org, org_config = config.project_config.keychain.get_default_org()
 
+    org_config = check_org_expired(config, org, org_config)
+    
     if delete_org and not org_config.scratch:
         raise click.UsageError(
             '--delete-org can only be used with a scratch org')

--- a/cumulusci/cli/cli.py
+++ b/cumulusci/cli/cli.py
@@ -679,7 +679,7 @@ def org_info(config, org_name, print_json):
         click.echo(render_recursive(org_config.config))
 
     if org_config.scratch and org_config.expires:
-        click.echo('Org expires on {}'.format(org_config.expires.strftime('%c')))
+        click.echo('Org expires on {:%c}'.format(org_config.expires))
         
     # Save the org config in case it was modified
     config.keychain.set_org(org_name, org_config)

--- a/cumulusci/core/config.py
+++ b/cumulusci/core/config.py
@@ -829,7 +829,7 @@ class ScratchOrgConfig(OrgConfig):
 
         # Call force:org:display and parse output to get instance_url and
         # access_token
-        command = 'sfdx force:org:display -u {} --json'.format(self.alias_or_username)
+        command = 'sfdx force:org:display -u {} --json'.format(self.username)
         p = sarge.Command(
             command,
             stderr=sarge.Capture(buffer_size=-1),
@@ -949,13 +949,6 @@ class ScratchOrgConfig(OrgConfig):
             delta = datetime.datetime.now() - self.date_created 
             return delta.days + 1
 
-    @property
-    def alias_or_username(self):
-        # FIXME: Commenting out for now to get through 7 days from the fix for aliases not being quoted
-        #if self.sfdx_alias:
-        #    return self.sfdx_alias
-        return self.username
-
     def create_org(self):
         """ Uses sfdx force:org:create to create the org """
         if not self.config_file:
@@ -1026,7 +1019,7 @@ class ScratchOrgConfig(OrgConfig):
 
         # Set a random password so it's available via cci org info
         command = 'sfdx force:user:password:generate -u {}'.format(
-            self.alias_or_username)
+            self.username)
         self.logger.info(
             'Generating scratch org user password with command {}'.format(command))
         p = sarge.Command(command, stdout=sarge.Capture(
@@ -1056,7 +1049,7 @@ class ScratchOrgConfig(OrgConfig):
                 'Skipping org deletion: the scratch org has not been created')
             return
 
-        command = 'sfdx force:org:delete -p -u {}'.format(self.alias_or_username)
+        command = 'sfdx force:org:delete -p -u {}'.format(self.username)
         self.logger.info(
             'Deleting scratch org with command {}'.format(command))
         p = sarge.Command(command, stdout=sarge.Capture(buffer_size=-1))
@@ -1083,7 +1076,7 @@ class ScratchOrgConfig(OrgConfig):
     def force_refresh_oauth_token(self):
         # Call force:org:display and parse output to get instance_url and
         # access_token
-        command = 'sfdx force:org:open -r -u {}'.format(self.alias_or_username)
+        command = 'sfdx force:org:open -r -u {}'.format(self.username)
         self.logger.info(
             'Refreshing OAuth token with command: {}'.format(command))
         p = sarge.Command(command, stdout=sarge.Capture(buffer_size=-1))

--- a/cumulusci/core/config.py
+++ b/cumulusci/core/config.py
@@ -932,7 +932,7 @@ class ScratchOrgConfig(OrgConfig):
 
     @property
     def days(self):
-        return self.config.get('days', 7)
+        return self.config.setdefault('days', 7)
 
     @property
     def expired(self):
@@ -957,27 +957,18 @@ class ScratchOrgConfig(OrgConfig):
         if not self.scratch_org_type:
             self.config['scratch_org_type'] = 'workspace'
 
-        devhub = ''
-        if self.devhub:
-            devhub = ' --targetdevhubusername {}'.format(self.devhub)
-
-        namespaced = ''
-        if not self.namespaced:
-            namespaced = ' -n'
-
-        days = ''
-        if self.days:
-            days = ' --durationdays {}'.format(self.days)
-
-        alias = ''
-        if self.sfdx_alias:
-            alias = ' -a {}'.format(self.sfdx_alias)
+        options = {
+            'config_file': self.config_file,
+            'devhub': ' --targetdevhubusername {}'.format(self.devhub) if self.devhub else '',
+            'namespaced': ' -n' if not self.namespaced else '',
+            'days': ' --durationdays {}'.format(self.days) if self.days else '',
+            'alias': ' -a {}'.format(self.sfdx_alias) if self.sfdx_alias else '',
+            'extraargs': os.environ.get('SFDX_ORG_CREATE_ARGS', ''),
+        }
 
         # This feels a little dirty, but the use cases for extra args would mostly
         # work best with env vars
-        extraargs = os.environ.get('SFDX_ORG_CREATE_ARGS', '')
-        command = 'sfdx force:org:create -f {}{}{}{}{} {}'.format(
-            self.config_file, devhub, namespaced, alias, days, extraargs)
+        command = 'sfdx force:org:create -f {config_file}{devhub}{namespaced}{days}{alias} {extraargs}'.format(**options)
         self.logger.info(
             'Creating scratch org with command {}'.format(command))
         p = sarge.Command(command, stdout=sarge.Capture(buffer_size=-1))

--- a/cumulusci/core/config.py
+++ b/cumulusci/core/config.py
@@ -932,7 +932,7 @@ class ScratchOrgConfig(OrgConfig):
 
     @property
     def days(self):
-        return self.config.setdefault('days', 7)
+        return self.config.setdefault('days', 1)
 
     @property
     def expired(self):

--- a/cumulusci/core/keychain.py
+++ b/cumulusci/core/keychain.py
@@ -51,18 +51,20 @@ class BaseProjectKeychain(BaseConfig):
         current_orgs = self.list_orgs()
         if not self.project_config.orgs__scratch:
             return
-        for org_name, scratch_config in self.project_config.orgs__scratch.items():
+        for org_name in self.project_config.orgs__scratch.keys():
             if org_name in current_orgs:
                 # Don't overwrite an existing keychain org
                 continue
-            days = scratch_config.get('days', 7)
-            self.create_scratch_org(org_name, org_name, scratch_config, days)
+            self.create_scratch_org(org_name, config_name)
 
     def _load_services(self):
         pass
             
-    def create_scratch_org(self, org_name, config_name, scratch_config, days):
+    def create_scratch_org(self, org_name, config_name, scratch_config, days=None):
         """ Adds/Updates a scratch org config to the keychain from a named config """
+        scratch_config = getattr(self.project_config, 'orgs__scratch__{}'.format(config_name))
+        if days is None:
+            days = scratch_config.get('days', 7)
         scratch_config['scratch'] = True
         scratch_config['namespaced'] = scratch_config.get('namespaced', False)
         scratch_config['config_name'] = config_name

--- a/cumulusci/core/keychain.py
+++ b/cumulusci/core/keychain.py
@@ -63,10 +63,9 @@ class BaseProjectKeychain(BaseConfig):
     def create_scratch_org(self, org_name, config_name, days=None):
         """ Adds/Updates a scratch org config to the keychain from a named config """
         scratch_config = getattr(self.project_config, 'orgs__scratch__{}'.format(config_name))
-        if days is None:
-            days = scratch_config.get('days', 7)
+        scratch_config.setdefault('days', 7)
         scratch_config['scratch'] = True
-        scratch_config['namespaced'] = scratch_config.get('namespaced', False)
+        scratch_config.setdefault('namespaced', False)
         scratch_config['config_name'] = config_name
         scratch_config['days'] = days
         scratch_config['sfdx_alias'] = '{}__{}'.format(

--- a/cumulusci/core/keychain.py
+++ b/cumulusci/core/keychain.py
@@ -55,16 +55,18 @@ class BaseProjectKeychain(BaseConfig):
             if org_name in current_orgs:
                 # Don't overwrite an existing keychain org
                 continue
-            self.create_scratch_org(org_name, org_name, scratch_config)
+            days = scratch_config.get('days', 7)
+            self.create_scratch_org(org_name, org_name, scratch_config, days)
 
     def _load_services(self):
         pass
             
-    def create_scratch_org(self, org_name, config_name, scratch_config):
+    def create_scratch_org(self, org_name, config_name, scratch_config, days):
         """ Adds/Updates a scratch org config to the keychain from a named config """
         scratch_config['scratch'] = True
         scratch_config['namespaced'] = scratch_config.get('namespaced', False)
         scratch_config['config_name'] = config_name
+        scratch_config['days'] = days
         scratch_config['sfdx_alias'] = '{}__{}'.format(
             self.project_config.project__name,
             org_name,

--- a/cumulusci/core/keychain.py
+++ b/cumulusci/core/keychain.py
@@ -51,16 +51,16 @@ class BaseProjectKeychain(BaseConfig):
         current_orgs = self.list_orgs()
         if not self.project_config.orgs__scratch:
             return
-        for org_name in self.project_config.orgs__scratch.keys():
-            if org_name in current_orgs:
+        for config_name in self.project_config.orgs__scratch.keys():
+            if config_name in current_orgs:
                 # Don't overwrite an existing keychain org
                 continue
-            self.create_scratch_org(org_name, config_name)
+            self.create_scratch_org(config_name, config_name)
 
     def _load_services(self):
         pass
             
-    def create_scratch_org(self, org_name, config_name, scratch_config, days=None):
+    def create_scratch_org(self, org_name, config_name, days=None):
         """ Adds/Updates a scratch org config to the keychain from a named config """
         scratch_config = getattr(self.project_config, 'orgs__scratch__{}'.format(config_name))
         if days is None:

--- a/cumulusci/cumulusci.yml
+++ b/cumulusci/cumulusci.yml
@@ -57,21 +57,6 @@ tasks:
             namespace_inject: $project_config.project__package__namespace
             namespace_token: '%%%NAMESPACE%%%'
             filename_token: '___NAMESPACE___'
-    dx_convert_to:
-        description: Converts src directory metadata format into sfdx format under force-app
-        class_path: cumulusci.tasks.sfdx.SFDXBaseTask
-        options:
-            command: 'force:mdapi:convert -r src'
-    dx_convert_from:
-        description: Converts force-app directory in sfdx format into metadata format under src
-        class_path: cumulusci.tasks.sfdx.SFDXBaseTask
-        options:
-            command: 'force:mdapi:convert -r force-app -d src'
-    dx_push:
-        description: Uses sfdx to push the force-app directory metadata into a scratch org
-        class_path: cumulusci.tasks.sfdx.SFDXOrgTask
-        options:
-            command: 'force:source:push'
     execute_anon:
         description: Execute a string of anonymous apex via the tooling api.
         class_path: cumulusci.tasks.apex.anon.AnonymousApexTask
@@ -582,10 +567,7 @@ orgs:
             days: 7
         feature:
             config_file: orgs/feature.json
-            days: 1
         beta:
             config_file: orgs/beta.json
-            days: 1
         release:
             config_file: orgs/release.json
-            days: 1

--- a/cumulusci/cumulusci.yml
+++ b/cumulusci/cumulusci.yml
@@ -57,6 +57,21 @@ tasks:
             namespace_inject: $project_config.project__package__namespace
             namespace_token: '%%%NAMESPACE%%%'
             filename_token: '___NAMESPACE___'
+    dx_convert_to:
+        description: Converts src directory metadata format into sfdx format under force-app
+        class_path: cumulusci.tasks.sfdx.SFDXBaseTask
+        options:
+            command: 'force:mdapi:convert -r src'
+    dx_convert_from:
+        description: Converts force-app directory in sfdx format into metadata format under src
+        class_path: cumulusci.tasks.sfdx.SFDXBaseTask
+        options:
+            command: 'force:mdapi:convert -r force-app -d src'
+    dx_push:
+        description: Uses sfdx to push the force-app directory metadata into a scratch org
+        class_path: cumulusci.tasks.sfdx.SFDXOrgTask
+        options:
+            command: 'force:source:push'
     execute_anon:
         description: Execute a string of anonymous apex via the tooling api.
         class_path: cumulusci.tasks.apex.anon.AnonymousApexTask
@@ -564,9 +579,13 @@ orgs:
     scratch:
         dev:
             config_file: orgs/dev.json
+            days: 14
         feature:
             config_file: orgs/feature.json
+            days: 1
         beta:
             config_file: orgs/beta.json
+            days: 1
         release:
             config_file: orgs/release.json
+            days: 1

--- a/cumulusci/cumulusci.yml
+++ b/cumulusci/cumulusci.yml
@@ -579,7 +579,7 @@ orgs:
     scratch:
         dev:
             config_file: orgs/dev.json
-            days: 14
+            days: 7
         feature:
             config_file: orgs/feature.json
             days: 1

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -12,9 +12,9 @@ Contents:
    :maxdepth: 2
 
    tutorial
+   features
    cookbook
    tasks
-   dependencies
    api_reference
    history
    authors


### PR DESCRIPTION
- Scratch org configs in cumulusci.yml can now specify a days attribute that sets the number of days the scratch org should persist (1-30)
- `cci org scratch` now supports the `--days N` option to override the days value on the scratch config
- Scratch orgs now have `date_created` stored in their config
- Scratch orgs now have new calculated properties: `expired`, `expires`, `days_alive`
- `cci org list` now shows days and if orgs are expired
- All cci commands that interact with an org from the keychain now check if the org is expired.  If the org is expired, the user is prompted to recreate the org config to continue