### PR TITLE
Avoid orphan scratch orgs from flow and task run

### DIFF
--- a/cumulusci/cli/cli.py
+++ b/cumulusci/cli/cli.py
@@ -929,10 +929,6 @@ def task_run(config, task_name, org, o, debug, debug_before, debug_after, no_pro
         except Exception as e:
             handle_exception_debug(config, debug, e, no_prompt=no_prompt)
 
-    # Save the org config in case it was modified in the task
-    if org and org_config:
-        config.keychain.set_org(org_config)
-
     if debug_after:
         import pdb
         pdb.set_trace()
@@ -1070,10 +1066,6 @@ def flow_run(config, flow_name, org, delete_org, debug, o, skip, no_prompt):
             click.echo(
                 'Scratch org deletion failed.  Ignoring the error below to complete the flow:')
             click.echo(e.message)
-
-    # Save the org config in case it was modified in a task
-    if org and org_config:
-        config.keychain.set_org(org, org_config)
 
     if exception:
         handle_sentry_event(config, no_prompt)

--- a/cumulusci/cli/cli.py
+++ b/cumulusci/cli/cli.py
@@ -137,6 +137,16 @@ def render_recursive(data, indent=None):
             else:
                 click.echo('{}{} {}'.format(indent_str, key_str, value))
 
+def check_org_overwrite(config, org_name):
+    try:
+        org = config.keychain.get_org(org_name)
+        raise click.ClickException(
+            'Org {} already exists.  Use `cci org remove` to delete it.'.format(org_name)
+        )
+    except OrgNotFound:
+        pass
+    return True
+
 class CliConfig(object):
 
     def __init__(self):
@@ -601,6 +611,7 @@ def org_browser(config, org_name):
 @pass_config
 def org_connect(config, org_name, sandbox, login_url, default, global_org):
     check_connected_app(config)
+    check_org_overwrite(config, org_name)
 
     connected_app = config.keychain.get_connected_app()
     if sandbox:
@@ -614,10 +625,10 @@ def org_connect(config, org_name, sandbox, login_url, default, global_org):
         scope='web full refresh_token'
     )
     oauth_dict = oauth_capture()
-    org_config = OrgConfig(oauth_dict)
+    org_config = OrgConfig(oauth_dict, org_name)
     org_config.load_userinfo()
 
-    config.keychain.set_org(org_name, org_config, global_org)
+    config.keychain.set_org(org_config, global_org)
 
     if default:
         org = config.keychain.set_default_org(org_name)
@@ -660,7 +671,7 @@ def org_info(config, org_name, print_json):
         click.echo(render_recursive(org_config.config))
 
     # Save the org config in case it was modified
-    config.keychain.set_org(org_name, org_config)
+    config.keychain.set_org(org_config)
 
 
 @click.command(name='list', help="Lists the connected orgs for the current project")
@@ -687,8 +698,18 @@ def org_list(config):
 @pass_config
 def org_remove(config, org_name, global_org):
     check_connected_app(config)
+
     try:
         org_config = config.keychain.get_org(org_name)
+        if isinstance(org_config, ScratchOrgConfig):
+            if 'username' in org_config:
+                # attempt to delete the org
+                try:
+                    click.echo("A scratch org was already created, attempting to delete...")
+                    org.delete_org()
+                except Exception as e:
+                    click.echo("Deleting scratch org failed with error:")
+                    click.echo(e)
     except OrgNotFound:
         raise click.ClickException('Org {} does not exist in the keychain'.format(org_name))
     config.keychain.remove_org(org_name, global_org)
@@ -702,6 +723,7 @@ def org_remove(config, org_name, global_org):
 @pass_config
 def org_scratch(config, config_name, org_name, default, delete, devhub):
     check_connected_app(config)
+    check_org_overwrite(config, org_name)
 
     scratch_configs = getattr(config.project_config, 'orgs__scratch')
     if not scratch_configs:
@@ -737,7 +759,7 @@ def org_scratch_delete(config, org_name):
     except ScratchOrgException as e:
         exception = click.UsageError(e.message)
 
-    config.keychain.set_org(org_name, org_config)
+    config.keychain.set_org(org_config)
 
 
 @click.command(name='connected_app', help="Displays the ConnectedApp info used for OAuth connections")
@@ -909,7 +931,7 @@ def task_run(config, task_name, org, o, debug, debug_before, debug_after, no_pro
 
     # Save the org config in case it was modified in the task
     if org and org_config:
-        config.keychain.set_org(org, org_config)
+        config.keychain.set_org(org_config)
 
     if debug_after:
         import pdb

--- a/cumulusci/cli/cli.py
+++ b/cumulusci/cli/cli.py
@@ -599,7 +599,7 @@ def org_browser(config, org_name):
     webbrowser.open(org_config.start_url)
 
     # Save the org config in case it was modified
-    config.keychain.set_org(org_name, org_config)
+    config.keychain.set_org(org_config)
 
 
 @click.command(name='connect', help="Connects a new org's credentials using OAuth Web Flow")

--- a/cumulusci/core/config.py
+++ b/cumulusci/core/config.py
@@ -1087,7 +1087,6 @@ class ScratchOrgConfig(OrgConfig):
         # Get org info via sfdx force:org:display
         self.scratch_info
 
-
 class ServiceConfig(BaseConfig):
     pass
 

--- a/cumulusci/core/config.py
+++ b/cumulusci/core/config.py
@@ -763,6 +763,10 @@ class ConnectedAppOAuthConfig(BaseConfig):
 class OrgConfig(BaseConfig):
     """ Salesforce org configuration (i.e. org credentials) """
 
+    def __init__(self, config, name):
+        self.name = name
+        super(OrgConfig, self).__init__(config)
+
     def refresh_oauth_token(self, connected_app):
         client_id = self.client_id
         client_secret = self.client_secret

--- a/cumulusci/core/flows.py
+++ b/cumulusci/core/flows.py
@@ -51,6 +51,17 @@ class BaseFlow(object):
         """ Initializes self.logger """
         self.logger = logging.getLogger(__name__)
 
+    def _init_org(self):
+        """ Refresh the token on the org """
+        self.logger.info('Verifying and refreshing credentials for target org {}'.format(self.org_config.name))
+        orig_config = self.org_config.config.copy()
+        self.org_config.refresh_oauth_token(
+            self.project_config.keychain.get_connected_app()
+        )
+        if self.org_config.config != orig_config:
+            self.logger.info('Org info has changed, updating org in keychain')
+            self.project_config.keychain.set_org(self.org_config)
+
     def _init_flow(self):
         """ Initialize the flow and print flow details to info """
         self.logger.info('---------------------------------------')
@@ -59,6 +70,9 @@ class BaseFlow(object):
             self.__class__.__name__,
         )
         self.logger.info('---------------------------------------')
+
+        self.logger.info('')
+        self._init_org()
         for line in self._render_config():
             self.logger.info(line)
 

--- a/cumulusci/core/tests/test_flows.py
+++ b/cumulusci/core/tests/test_flows.py
@@ -3,16 +3,16 @@ from __future__ import unicode_literals
 
 import unittest
 import logging
+import mock
 
 from collections import Callable
 
 from cumulusci.core.flows import BaseFlow
 from cumulusci.core.tasks import BaseTask
-from cumulusci.core.config import BaseGlobalConfig
-from cumulusci.core.config import BaseProjectConfig
 from cumulusci.core.config import FlowConfig
 from cumulusci.core.config import OrgConfig
 from cumulusci.core.tests.utils import MockLoggingHandler
+from cumulusci.tests.util import create_project_config
 import cumulusci.core
 
 ORG_ID = "00D000000000001"
@@ -45,7 +45,7 @@ class _SfdcTask(BaseTask):
     def _run_task(self):
         return -1
 
-
+@mock.patch('cumulusci.core.flows.BaseFlow._init_org')
 class TestBaseFlow(unittest.TestCase):
     """ Tests the expectations of a BaseFlow caller """
 
@@ -58,8 +58,7 @@ class TestBaseFlow(unittest.TestCase):
         logger.addHandler(cls._flow_log_handler)
 
     def setUp(self):
-        self.global_config = BaseGlobalConfig()
-        self.project_config = BaseProjectConfig(self.global_config)
+        self.project_config = create_project_config('TestOwner', 'TestRepo')
         self.project_config.config['tasks'] = {
             'pass_name': {
                 'description': 'Pass the name',
@@ -94,23 +93,25 @@ class TestBaseFlow(unittest.TestCase):
         self._flow_log_handler.reset()
         self.flow_log = self._flow_log_handler.messages
 
-    def test_init(self):
+    def test_init(self, mock_class):
         """ BaseFlow initializes and offers a logger """
         flow_config = FlowConfig({})
+        mock_class.return_value = None
         flow = BaseFlow(self.project_config, flow_config, self.org_config)
 
         self.assertEquals(hasattr(flow, 'logger'), True)
 
-    def test_is_callable(self):
+    def test_is_callable(self, mock_class):
         """ BaseFlow exposes itself as a callable for use """
         flow_config = FlowConfig({})
         flow = BaseFlow(self.project_config, flow_config, self.org_config)
 
         self.assertIsInstance(flow, Callable)
 
-    def test_pass_around_values(self):
+    def test_pass_around_values(self, mock_class):
         """ A flow's options reach into return values from other tasks. """
 
+        mock_class.return_value = None
         # instantiate a flow with two tasks
         flow_config = FlowConfig({
             'description': 'Run two tasks',
@@ -129,9 +130,10 @@ class TestBaseFlow(unittest.TestCase):
         # the flow results for the second task should be 'name'
         self.assertEquals('supername', flow.task_results[1])
 
-    def test_task_options(self):
+    def test_task_options(self, mock_class):
         """ A flow can accept task options and pass them to the task. """
 
+        mock_class.return_value = None
         # instantiate a flow with two tasks
         flow_config = FlowConfig({
             'description': 'Run two tasks',
@@ -154,7 +156,7 @@ class TestBaseFlow(unittest.TestCase):
         # the flow results for the first task should be 'bar'
         self.assertEquals('bar', flow.task_results[0])
 
-    def test_skip_kwarg(self):
+    def test_skip_kwarg(self, mock_class):
         """ A flow can receive during init a list of tasks to skip """
 
         # instantiate a flow with two tasks
@@ -181,7 +183,7 @@ class TestBaseFlow(unittest.TestCase):
         # the number of tasks in the flow should be 1 instead of 2
         self.assertEquals(1, len(flow.task_results))
 
-    def test_skip_task_value_none(self):
+    def test_skip_task_value_none(self, mock_class):
         """ A flow skips any tasks whose name is None to allow override via yaml """
 
         # instantiate a flow with two tasks
@@ -206,7 +208,7 @@ class TestBaseFlow(unittest.TestCase):
         # the number of tasks in the flow should be 1 instead of 2
         self.assertEquals(1, len(flow.task_results))
 
-    def test_find_task_by_name_no_tasks(self):
+    def test_find_task_by_name_no_tasks(self, mock_class):
         """ The _find_task_by_name method skips tasks that don't exist """
 
         # instantiate a flow with two tasks
@@ -222,7 +224,7 @@ class TestBaseFlow(unittest.TestCase):
 
         self.assertEquals(None, flow._find_task_by_name('missing'))
 
-    def test_find_task_by_name_not_first(self):
+    def test_find_task_by_name_not_first(self, mock_class):
         """ The _find_task_by_name method skips tasks that don't exist """
 
         # instantiate a flow with two tasks
@@ -250,7 +252,7 @@ class TestBaseFlow(unittest.TestCase):
             task.task_config.class_path,
         )
 
-    def test_render_task_config_empty_value(self):
+    def test_render_task_config_empty_value(self, mock_class):
         """ The _render_task_config method skips option values of None """
 
         # instantiate a flow with two tasks
@@ -278,7 +280,7 @@ class TestBaseFlow(unittest.TestCase):
         config = flow._render_task_config(task)
         self.assertEquals(['Options:'], config)
 
-    def test_task_raises_exception_fail(self):
+    def test_task_raises_exception_fail(self, mock_class):
         """ A flow aborts when a task raises an exception """
 
         flow_config = FlowConfig({
@@ -290,7 +292,7 @@ class TestBaseFlow(unittest.TestCase):
         flow = BaseFlow(self.project_config, flow_config, self.org_config)
         self.assertRaises(Exception, flow)
 
-    def test_task_raises_exception_ignore(self):
+    def test_task_raises_exception_ignore(self, mock_class):
         """ A flow continues when a task configured with ignore_failure raises an exception """
 
         flow_config = FlowConfig({
@@ -304,7 +306,7 @@ class TestBaseFlow(unittest.TestCase):
         flow()
         self.assertEquals(2, len(flow.tasks))
 
-    def test_call_no_tasks(self):
+    def test_call_no_tasks(self, mock_class):
         """ A flow with no tasks will have no responses. """
         flow_config = FlowConfig({
             'description': 'Run no tasks',
@@ -316,7 +318,7 @@ class TestBaseFlow(unittest.TestCase):
         self.assertEqual([], flow.task_return_values)
         self.assertEqual([], flow.tasks)
 
-    def test_call_one_task(self):
+    def test_call_one_task(self, mock_class):
         """ A flow with one task will execute the task """
         flow_config = FlowConfig({
             'description': 'Run one task',
@@ -334,7 +336,7 @@ class TestBaseFlow(unittest.TestCase):
         self.assertEqual([{'name': 'supername'}], flow.task_return_values)
         self.assertEqual(1, len(flow.tasks))
 
-    def test_call_many_tasks(self):
+    def test_call_many_tasks(self, mock_class):
         """ A flow with many tasks will dispatch each task """
         flow_config = FlowConfig({
             'description': 'Run two tasks',
@@ -352,7 +354,7 @@ class TestBaseFlow(unittest.TestCase):
         )
         self.assertEqual(2, len(flow.tasks))
 
-    def test_call_task_not_found(self):
+    def test_call_task_not_found(self, mock_class):
         """ A flow with reference to a task that doesn't exist in the
         project will throw an AttributeError """
 
@@ -367,7 +369,7 @@ class TestBaseFlow(unittest.TestCase):
 
         self.assertRaises(AttributeError, flow)
 
-    def test_flow_prints_org_id(self):
+    def test_flow_prints_org_id(self, mock_class):
         """ A flow with an org prints the org ID """
 
         flow_config = FlowConfig({
@@ -384,7 +386,7 @@ class TestBaseFlow(unittest.TestCase):
 
         self.assertEqual(1, len(org_id_logs))
 
-    def test_flow_no_org_no_org_id(self):
+    def test_flow_no_org_no_org_id(self, mock_class):
         """ A flow without an org does not print the org ID """
 
         flow_config = FlowConfig({
@@ -401,7 +403,7 @@ class TestBaseFlow(unittest.TestCase):
             ORG_ID in s for s in self.flow_log['info']
         ))
 
-    def test_flow_prints_org_id_once_only(self):
+    def test_flow_prints_org_id_once_only(self, mock_class):
         """ A flow with sf tasks prints the org ID only once."""
 
         flow_config = FlowConfig({

--- a/cumulusci/core/tests/test_flows.py
+++ b/cumulusci/core/tests/test_flows.py
@@ -89,7 +89,7 @@ class TestBaseFlow(unittest.TestCase):
         self.org_config = OrgConfig({
             'username': 'sample@example',
             'org_id': ORG_ID
-        })
+        }, 'test')
 
         self._flow_log_handler.reset()
         self.flow_log = self._flow_log_handler.messages

--- a/cumulusci/core/tests/test_keychain.py
+++ b/cumulusci/core/tests/test_keychain.py
@@ -54,8 +54,8 @@ class TestBaseProjectKeychain(unittest.TestCase):
             'mrbelvedere': ServiceConfig({'mr': 'belvedere'}),
             'apextestsdb': ServiceConfig({'apex': 'testsdb'}),
         }
-        self.org_config = OrgConfig({'foo': 'bar'})
-        self.scratch_org_config = ScratchOrgConfig({'foo': 'bar', 'scratch': True})
+        self.org_config = OrgConfig({'foo': 'bar'}, 'test')
+        self.scratch_org_config = ScratchOrgConfig({'foo': 'bar', 'scratch': True}, 'test_scratch')
         self.key = '0123456789123456'
 
     def test_init(self):
@@ -98,7 +98,7 @@ class TestBaseProjectKeychain(unittest.TestCase):
     def _test_change_key(self):
         new_key = '9876543210987654'
         keychain = self.keychain_class(self.project_config, self.key)
-        keychain.set_org('test', self.org_config)
+        keychain.set_org(self.org_config)
         keychain.set_connected_app(self.connected_app_config)
         keychain.set_service('github', self.services['github'])
         keychain.set_service('mrbelvedere', self.services['mrbelvedere'])
@@ -159,7 +159,7 @@ class TestBaseProjectKeychain(unittest.TestCase):
 
     def _test_set_and_get_org(self, global_org=False):
         keychain = self.keychain_class(self.project_config, self.key)
-        keychain.set_org('test', self.org_config, global_org)
+        keychain.set_org(self.org_config, global_org)
         self.assertEquals(list(keychain.orgs.keys()), ['test'])
         self.assertEquals(keychain.get_org(
             'test').config, self.org_config.config)
@@ -169,9 +169,9 @@ class TestBaseProjectKeychain(unittest.TestCase):
 
     def _test_set_and_get_scratch_org(self, global_org=False):
         keychain = self.keychain_class(self.project_config, self.key)
-        keychain.set_org('test', self.scratch_org_config, global_org)
-        self.assertEquals(list(keychain.orgs.keys()), ['test'])
-        org = keychain.get_org('test')
+        keychain.set_org(self.scratch_org_config, global_org)
+        self.assertEquals(list(keychain.orgs.keys()), ['test_scratch'])
+        org = keychain.get_org('test_scratch')
         self.assertEquals(
             org.config,
             self.scratch_org_config.config,
@@ -206,7 +206,7 @@ class TestBaseProjectKeychain(unittest.TestCase):
         self.project_config.config['orgs']['scratch'] = {}
         self.project_config.config['orgs']['scratch']['test'] = {}
         keychain = self.keychain_class(self.project_config, self.key)
-        keychain.set_org('test', OrgConfig())
+        keychain.set_org(OrgConfig({}, 'test'))
         self.assertEquals(list(keychain.orgs), ['test'])
         org = keychain.get_org('test')
         self.assertEquals(org.scratch, None)
@@ -225,9 +225,9 @@ class TestBaseProjectKeychain(unittest.TestCase):
     def _test_get_default_org(self):
         keychain = self.keychain_class(self.project_config, self.key)
         org_config = self.org_config.config.copy()
-        org_config = OrgConfig(org_config)
+        org_config = OrgConfig(org_config, 'test')
         org_config.config['default'] = True
-        keychain.set_org('test', org_config)
+        keychain.set_org(org_config)
         self.assertEquals(keychain.get_default_org()[
                           1].config, org_config.config)
 
@@ -244,8 +244,8 @@ class TestBaseProjectKeychain(unittest.TestCase):
     def _test_set_default_org(self):
         keychain = self.keychain_class(self.project_config, self.key)
         org_config = self.org_config.config.copy()
-        org_config = OrgConfig(org_config)
-        keychain.set_org('test', org_config)
+        org_config = OrgConfig(org_config, 'test')
+        keychain.set_org(org_config)
         keychain.set_default_org('test')
         expected_org_config = org_config.config.copy()
         expected_org_config['default'] = True
@@ -261,9 +261,9 @@ class TestBaseProjectKeychain(unittest.TestCase):
     def _test_unset_default_org(self):
         keychain = self.keychain_class(self.project_config, self.key)
         org_config = self.org_config.config.copy()
-        org_config = OrgConfig(org_config)
+        org_config = OrgConfig(org_config, 'test')
         org_config.config['default'] = True
-        keychain.set_org('test', org_config)
+        keychain.set_org(org_config)
         keychain.unset_default_org()
         self.assertEquals(keychain.get_default_org()[1], None)
 
@@ -272,7 +272,7 @@ class TestBaseProjectKeychain(unittest.TestCase):
 
     def _test_list_orgs(self):
         keychain = self.keychain_class(self.project_config, self.key)
-        keychain.set_org('test', self.org_config)
+        keychain.set_org(self.org_config)
         self.assertEquals(keychain.list_orgs(), ['test'])
 
     def test_list_orgs_empty(self):
@@ -424,7 +424,7 @@ class TestBaseEncryptedProjectKeychain(TestBaseProjectKeychain):
 
     def test_decrypt_config_no_config(self):
         keychain = self.keychain_class(self.project_config, self.key)
-        config = keychain._decrypt_config(OrgConfig, None)
+        config = keychain._decrypt_config(OrgConfig, None, extra=['test'])
         self.assertEquals(config.__class__, OrgConfig)
         self.assertEquals(config.config, {})
 
@@ -445,8 +445,8 @@ class TestEncryptedFileProjectKeychain(TestBaseProjectKeychain):
         self.project_config.project__name = 'TestProject'
         self.project_name = 'TestProject'
         self.connected_app_config = ConnectedAppOAuthConfig({'test': 'value'})
-        self.org_config = OrgConfig({'foo': 'bar'})
-        self.scratch_org_config = ScratchOrgConfig({'foo': 'bar', 'scratch': True})
+        self.org_config = OrgConfig({'foo': 'bar'}, 'test')
+        self.scratch_org_config = ScratchOrgConfig({'foo': 'bar', 'scratch': True}, 'test_scratch')
         self.services = {
             'github': ServiceConfig({'git': 'hub'}),
             'mrbelvedere': ServiceConfig({'mr': 'belvedere'}),

--- a/cumulusci/core/tests/test_tasks.py
+++ b/cumulusci/core/tests/test_tasks.py
@@ -4,6 +4,7 @@ from __future__ import unicode_literals
 import unittest
 import logging
 import collections
+import mock
 
 from cumulusci.core.tasks import BaseTask
 from cumulusci.core.flows import BaseFlow
@@ -145,9 +146,11 @@ class TestBaseTaskCallable(unittest.TestCase):
             ORG_ID in s for s in self.task_log['info']
         ))
 
-    def test_no_id_if_run_from_flow(self):
+    @mock.patch('cumulusci.core.flows.BaseFlow._init_org')
+    def test_no_id_if_run_from_flow(self, mock_class):
         """ A salesforce_task will not log the org id if run from a flow """
 
+        mock_class.return_value = None
         task = _SfdcTask(
             self.project_config,
             self.task_config,

--- a/cumulusci/core/tests/test_tasks.py
+++ b/cumulusci/core/tests/test_tasks.py
@@ -56,7 +56,7 @@ class TestBaseTaskCallable(unittest.TestCase):
         self.org_config = OrgConfig({
             'username': USERNAME,
             'org_id': ORG_ID
-        })
+        }, 'test')
         self.task_config = TaskConfig()
         self._task_log_handler.reset()
         self.task_log = self._task_log_handler.messages

--- a/cumulusci/tasks/apex/tests/test_salesforce.py
+++ b/cumulusci/tasks/apex/tests/test_salesforce.py
@@ -37,7 +37,7 @@ class TestRunApexTests(unittest.TestCase):
             'id': 'foo/1',
             'instance_url': 'example.com',
             'access_token': 'abc123',
-        })
+        }, 'test')
         self.base_tooling_url = 'https://{}/services/data/v{}/tooling/'.format(
             self.org_config.instance_url, self.api_version)
 

--- a/cumulusci/tasks/salesforce.py
+++ b/cumulusci/tasks/salesforce.py
@@ -56,11 +56,11 @@ class BaseSalesforceTask(BaseTask):
             'Subclasses should provide their own implementation')
 
     def _update_credentials(self):
-        orig_config = self.org_config.copy()
+        orig_config = self.org_config.config.copy()
         self.org_config.refresh_oauth_token(self.project_config.keychain.get_connected_app())
         if self.org_config.config != orig_config:
+            self.logger.info('Org info updated, writing to keychain')
             self.project_config.keychain.set_org(self.org_config)
-
 
 class BaseSalesforceMetadataApiTask(BaseSalesforceTask):
     api_class = None

--- a/cumulusci/tasks/salesforce.py
+++ b/cumulusci/tasks/salesforce.py
@@ -56,7 +56,10 @@ class BaseSalesforceTask(BaseTask):
             'Subclasses should provide their own implementation')
 
     def _update_credentials(self):
+        orig_config = self.org_config.copy()
         self.org_config.refresh_oauth_token(self.project_config.keychain.get_connected_app())
+        if self.org_config.config != orig_config:
+            self.project_config.keychain.set_org(self.org_config)
 
 
 class BaseSalesforceMetadataApiTask(BaseSalesforceTask):

--- a/cumulusci/tasks/tests/test_salesforce.py
+++ b/cumulusci/tasks/tests/test_salesforce.py
@@ -31,7 +31,7 @@ class TestSalesforceToolingTask(unittest.TestCase):
         self.org_config = OrgConfig({
             'instance_url': 'example.com',
             'access_token': 'abc123',
-        })
+        }, 'test')
         self.base_tooling_url = 'https://{}/services/data/v{}/tooling/'.format(
             self.org_config.instance_url, self.api_version)
 

--- a/cumulusci/tasks/tests/test_sfdx.py
+++ b/cumulusci/tasks/tests/test_sfdx.py
@@ -74,7 +74,7 @@ class TestSFDXBaseTask(unittest.TestCase):
         org_config = OrgConfig({
             'access_token': access_token,
             'instance_url': 'https://test.salesforce.com'
-        })
+        },'test')
 
         task = SFDXOrgTask(
             self.project_config, self.task_config, org_config
@@ -98,7 +98,7 @@ class TestSFDXBaseTask(unittest.TestCase):
         org_config = OrgConfig({
             'access_token': 'test access token',
             'instance_url': 'test instance url',
-        })
+        }, 'test')
 
         task = SFDXOrgTask(
             self.project_config, self.task_config, org_config

--- a/cumulusci/tests/util.py
+++ b/cumulusci/tests/util.py
@@ -58,5 +58,10 @@ class DummyProjectConfig(BaseProjectConfig):
         return self._repo_commit
         
 class DummyOrgConfig(OrgConfig):
+    def __init__(self, config=None, name=None):
+        if not name:
+            name = 'test'
+        super(DummyOrgConfig, self).__init__(config, name)
+
     def refresh_oauth_token(self):
         pass


### PR DESCRIPTION
This branch changes flows and tasks so they will always write a modified org config back to the keychain.  This helps avoid the scenario where `cci flow run` or `cci task run` creates a scratch org, fails, then fails to write the scratch org info into cci keychain which effectively creates an orphaned scratch org.