### PR TITLE
Beta79: Bug fix release for #520

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,11 @@
 History
 =======
 
+2.0.0-beta79 (2017-11-30)
+-------------------------
+
+* Fixes #540: Using a custom `prefix_beta` fails if releases with the same version but different prefix already exist in the repository.  Changed to use `tag_name` instead of `name` to check if the release already exists in Github.
+
 2.0.0-beta78 (2017-11-22)
 -------------------------
 

--- a/cumulusci/__init__.py
+++ b/cumulusci/__init__.py
@@ -1,5 +1,5 @@
 from __future__ import unicode_literals
 import os
 __import__('pkg_resources').declare_namespace('cumulusci')
-__version__ = '2.0.0-beta78'
+__version__ = '2.0.0-beta79'
 __location__ = os.path.dirname(os.path.realpath(__file__))

--- a/cumulusci/cli/cli.py
+++ b/cumulusci/cli/cli.py
@@ -882,7 +882,8 @@ def task_run(config, task_name, org, o, debug, debug_before, debug_after, no_pro
         org_config = config.project_config.get_org(org)
     else:
         org, org_config = config.project_config.keychain.get_default_org()
-    org_config = check_org_expired(config, org, org_config)
+    if org_config:
+        org_config = check_org_expired(config, org, org_config)
     task_config = getattr(config.project_config, 'tasks__{}'.format(task_name))
     if not task_config:
         raise TaskNotFoundError('Task not found: {}'.format(task_name))

--- a/cumulusci/tasks/github/release.py
+++ b/cumulusci/tasks/github/release.py
@@ -23,8 +23,11 @@ class CreateRelease(BaseGithubTask):
     def _run_task(self):
         repo = self.get_repo()
 
+        version = self.options['version']
+        self.tag_name = self.project_config.get_tag_for_version(version)
+
         for release in repo.iter_releases():
-            if release.name == self.options['version']:
+            if release.tag_name == self.tag_name:
                 message = 'Release {} already exists at {}'.format(release.name, release.html_url)
                 self.logger.error(message)
                 raise GithubException(message)
@@ -35,8 +38,6 @@ class CreateRelease(BaseGithubTask):
             self.logger.error(message)
             raise GithubException(message)
 
-        version = self.options['version']
-        self.tag_name = self.project_config.get_tag_for_version(version)
 
         ref = repo.ref('tags/{}'.format(self.tag_name))
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,7 +2,7 @@
 build-base=pybuild
 
 [bumpversion]
-current_version = 2.0.0-beta78
+current_version = 2.0.0-beta79
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ test_requirements = [
 
 setup(
     name='cumulusci',
-    version='2.0.0-beta78',
+    version='2.0.0-beta79',
     description="Build and release tools for Salesforce developers",
     long_description=readme + '\n\n' + history,
     author="Jason Lantz",


### PR DESCRIPTION
Fixes #520 and also fixes a newly introduced bug in `cci task run` when trying to run a task that doesn't require a Salesforce org and none is specified via `--org <name>`