### PR TITLE
Allow github dependencies to specify a tag

### DIFF
--- a/cumulusci/core/exceptions.py
+++ b/cumulusci/core/exceptions.py
@@ -40,6 +40,9 @@ class ServiceNotValid(CumulusCIException):
     """ Raised when no service configuration could be found by a given name in the project configuration """
     pass
 
+class DependencyResolutionError(CumulusCIException):
+    """ Raised when an issue is encountered while resolving a static dependency map """
+    pass
 
 class ConfigError(CumulusCIException):
     """ Raised when a configuration enounters an error """


### PR DESCRIPTION
- Removes the previous implementation of the `version` option on github
  dependencies
- If a tag is specified, it will be used for all retrieves of content
  from the repo (cumulusci.yml, unpackaged/*, and src)
- The tag is not recursive to dependencies specified by the referenced
  project.  If the referenced project has a github dependency without a
tag, the latest version of that dependency will be installed