### PR TITLE
Clean meta.xml of namespace version references on deploy

### DIFF
--- a/cumulusci/tasks/salesforce.py
+++ b/cumulusci/tasks/salesforce.py
@@ -394,7 +394,7 @@ class Deploy(BaseSalesforceMetadataApiTask):
         return zipf
 
     def _process_meta_xml(self, zipf):
-        if self.options.get('clean_meta_xml') == 'False':
+        if not process_bool_arg(self.options.get('clean_meta_xml', True)):
             return zipf
 
         self.logger.info(

--- a/cumulusci/tasks/salesforce.py
+++ b/cumulusci/tasks/salesforce.py
@@ -41,6 +41,7 @@ from cumulusci.utils import CUMULUSCI_PATH
 from cumulusci.utils import download_extract_zip
 from cumulusci.utils import findReplace
 from cumulusci.utils import package_xml_from_dict
+from cumulusci.utils import zip_clean_metaxml
 from cumulusci.utils import zip_inject_namespace
 from cumulusci.utils import zip_strip_namespace
 from cumulusci.utils import zip_tokenize_namespace
@@ -332,6 +333,9 @@ class Deploy(BaseSalesforceMetadataApiTask):
         'namespaced_org': {
             'description': "If True, the tokens %%%NAMESPACED_ORG%%% and ___NAMESPACED_ORG___ will get replaced with the namespace.  The default is false causing those tokens to get stripped and replaced with an empty string.  Set this if deploying to a namespaced scratch org or packaging org.",
         },
+        'clean_meta_xml': {
+            'description': "Defaults to True which strips the <packageVersions/> element from all meta.xml files.  The packageVersion element gets added automatically by the target org and is set to whatever version is installed in the org.  To disable this, set this option to False",
+        },
     }
         
     def _get_api(self, path=None):
@@ -358,6 +362,7 @@ class Deploy(BaseSalesforceMetadataApiTask):
 
     def _process_zip_file(self, zipf):
         zipf = self._process_namespace(zipf)
+        zipf = self._process_meta_xml(zipf)
         return zipf
         
     def _process_namespace(self, zipf):
@@ -386,6 +391,16 @@ class Deploy(BaseSalesforceMetadataApiTask):
             zipf = zip_inject_namespace(zipf, self.options['namespace_inject'], **kwargs)
         if self.options.get('namespace_strip'):
             zipf = zip_strip_namespace(zipf, self.options['namespace_strip'], logger=self.logger)
+        return zipf
+
+    def _process_meta_xml(self, zipf):
+        if self.options.get('clean_meta_xml') == 'False':
+            return zipf
+
+        self.logger.info(
+            'Cleaning meta.xml files of packageVersion elements for deploy'
+        )
+        zipf = zip_clean_metaxml(zipf, logger=self.logger)
         return zipf
 
     def _write_zip_file(self, zipf, root, path):


### PR DESCRIPTION
Since CumulusCI already handles dependencies, deploying meta.xml files containing the `<packageVersions>` element and its children (namespace, majorVersion, and minorVersion) can cause errors if the versions don't match up.  That previously required a commit to update all the meta.xml files to a new underlying package version.

This change automatically strips the `<packageVersion>` element and its children from all meta.xml files by default on all Deploy based tasks.  The target Salesforce org will automatically add those elements back using whatever version of the referenced package is installed in the org.  This way, CumulusCI gets to fully manage the dependencies.

Since the meta.xml files are updated by the org automatically, this should have no impact on packaging orgs or managed packages since the `update_dependencies` task would already have updated the dependent package versions in the org.

The `clean_meta_xml` option can be set to False to disable the functionality if needed.