### PR TITLE
filter sobjects by record type in bulkdataretrieve

### DIFF
--- a/cumulusci/tasks/bulkdata.py
+++ b/cumulusci/tasks/bulkdata.py
@@ -28,7 +28,6 @@ from sqlalchemy import types
 from sqlalchemy import event
 from StringIO import StringIO
 
-# TODO: Record Type Filter
 # TODO: UserID Catcher
 # TODO: Dater
 
@@ -444,6 +443,7 @@ class QueryData(BaseSalesforceApiTask):
     def _create_tables(self):
         for name, mapping in self.mappings.items():
             self._create_table(mapping)
+        self.metadata.create_all()
 
     def _fields_for_mapping(self, mapping):
         fields = []
@@ -473,5 +473,6 @@ class QueryData(BaseSalesforceApiTask):
             *fields,
             **table_kwargs
         )
-        self.metadata.create_all()
+        
+        
         mapper(self.models[mapping['table']], t, **mapper_kwargs)

--- a/cumulusci/tasks/bulkdata.py
+++ b/cumulusci/tasks/bulkdata.py
@@ -28,6 +28,10 @@ from sqlalchemy import types
 from sqlalchemy import event
 from StringIO import StringIO
 
+# TODO: Record Type Filter
+# TODO: UserID Catcher
+# TODO: Dater
+
 # Create a custom sqlalchemy field type for sqlite datetime fields which are stored as integer of epoch time
 class EpochType(types.TypeDecorator):
     impl = types.Integer
@@ -388,6 +392,8 @@ class QueryData(BaseSalesforceApiTask):
             'fields': ', '.join(fields),
             'sf_object': sf_object,
         })
+        if 'record_type' in mapping:
+            soql += ' WHERE RecordType.DeveloperName = \'{}\''.format(mapping['record_type'])
         return soql
 
     def _run_query(self, soql, mapping):

--- a/docs/bulk_data.rst
+++ b/docs/bulk_data.rst
@@ -40,6 +40,7 @@ Mapping File
             FieldAPIName: True
             AnotherFieldAPIName: MonthlyLiteral
 
+
 Example
 ^^^^^^^
 
@@ -77,3 +78,4 @@ Example
                 table: organizations
                 join_field: organization_id
                 value_field: sf_id
+

--- a/docs/bulk_data.rst
+++ b/docs/bulk_data.rst
@@ -11,6 +11,9 @@ Runs the mapping YAML in order, from top to bottom, selecting data from the spec
 sf_object and inserting it into the local table.
 
 LoadData
+^^^^^^^^
+Runs the mapping YAML in order, selecting data from the local table and inserting into the
+specified sf_object 
 
 
 Mapping File
@@ -18,7 +21,7 @@ Mapping File
 
 .. code-block:: yaml
     Step Name: (must be unique)
-        api: [(bulk)|sobject] (not yet implemented)
+        api: [(bulk)|sobject] (not yet implemented, specify which API to use to load data)
         sf_object: API Name for sfdc object
         table: full table name in sqlite3
         filters: used to filter the sqlite3 table when loading data

--- a/docs/bulk_data.rst
+++ b/docs/bulk_data.rst
@@ -6,6 +6,7 @@ Mapping File
 ===========
 
 Step Name: (must be unique)
+    api: [(bulk)|sobject]
     sf_object: API Name for sfdc object
     table: full table name in sqlite3
     filters: used to filter the sqlite3 table when loading data

--- a/docs/bulk_data.rst
+++ b/docs/bulk_data.rst
@@ -16,10 +16,10 @@ Step Name: (must be unique)
         API Name: sqlite3 name
     lookups:
         ForeignKeyAPIName (e.g. AccountId):
-            key_field
-            table
-            join_field
-            value_field
+            key_field (field on CURRENT table (specified in step.table) that contains the foreign key)
+            table (table to join to)
+            join_field (field on table just specified that contains the referenced key. usually id/pk)
+            value_field (field on the joined table to use as value, usually sf_id)
     static:
         FieldAPIName: True
         AnotherFieldAPIName: MonthlyLiteral

--- a/docs/bulk_data.rst
+++ b/docs/bulk_data.rst
@@ -20,6 +20,7 @@ Mapping File
 ============
 
 .. code-block:: yaml
+
     Step Name: (must be unique)
         api: [(bulk)|sobject] (not yet implemented, specify which API to use to load data)
         sf_object: API Name for sfdc object
@@ -45,6 +46,7 @@ Example
 ^^^^^^^
 
 .. code-block:: yaml    
+
     Insert Organizations:
         sf_object: Account
         table: organizations

--- a/docs/bulk_data.rst
+++ b/docs/bulk_data.rst
@@ -1,0 +1,61 @@
+=========
+Bulk Data
+=========
+
+Mapping File
+===========
+
+Step Name: (must be unique)
+    sf_object: API Name for sfdc object
+    table: full table name in sqlite3
+    filters: used to filter the sqlite3 table when loading data
+        - 'sql string' 
+    record_type: API Name (for insert/query)
+    fields:
+        Id: sf_id
+        API Name: sqlite3 name
+    lookups:
+        ForeignKeyAPIName (e.g. AccountId):
+            key_field
+            table
+            join_field
+            value_field
+    static:
+        FieldAPIName: True
+        AnotherFieldAPIName: MonthlyLiteral
+
+
+
+Insert Organizations:
+    sf_object: Account
+    table: organizations
+    fields:
+        Id: sf_id
+        Name: organization
+    record_type: Organization
+
+
+Insert Household Contacts:
+    sf_object: Contact
+    table: contacts
+    filters:
+        - 'household_id is not null'
+    fields:
+        Id: sf_id
+        Salutation: salutation
+        FirstName: first_name
+        LastName: last_name
+        Email: email
+        Phone: phone
+        Title: job_title
+    lookups:
+        AccountId:
+            key_field: household_id
+            table: households
+            join_field: household_id
+            value_field: sf_id
+        Primary_Affiliation__c: 
+            key_field: organization_id
+            table: organizations
+            join_field: organization_id
+            value_field: sf_id

--- a/docs/bulk_data.rst
+++ b/docs/bulk_data.rst
@@ -2,61 +2,75 @@
 Bulk Data
 =========
 
+The cumulusci.tasks.bulkdata module contains three tasks for dealing with 
+test and sample data.
+
+QueryData
+^^^^^^^^^
+Runs the mapping YAML in order, from top to bottom, selecting data from the specified
+sf_object and inserting it into the local table.
+
+LoadData
+
+
 Mapping File
-===========
+============
 
-Step Name: (must be unique)
-    api: [(bulk)|sobject]
-    sf_object: API Name for sfdc object
-    table: full table name in sqlite3
-    filters: used to filter the sqlite3 table when loading data
-        - 'sql string' 
-    record_type: API Name (for insert/query)
-    fields:
-        Id: sf_id
-        API Name: sqlite3 name
-    lookups:
-        ForeignKeyAPIName (e.g. AccountId):
-            key_field (field on CURRENT table (specified in step.table) that contains the foreign key)
-            table (table to join to)
-            join_field (field on table just specified that contains the referenced key. usually id/pk)
-            value_field (field on the joined table to use as value, usually sf_id)
-    static:
-        FieldAPIName: True
-        AnotherFieldAPIName: MonthlyLiteral
+.. code-block:: yaml
+    Step Name: (must be unique)
+        api: [(bulk)|sobject] (not yet implemented)
+        sf_object: API Name for sfdc object
+        table: full table name in sqlite3
+        filters: used to filter the sqlite3 table when loading data
+            - 'sql string' 
+        record_type: API Name (for insert/query)
+        fields:
+            Id: sf_id
+            API Name: sqlite3 name
+        lookups:
+            ForeignKeyAPIName (e.g. AccountId):
+                key_field (field on CURRENT table (specified in step.table) that contains the foreign key)
+                table (table to join to)
+                join_field (field on table just specified that contains the referenced key. usually id/pk)
+                value_field (field on the joined table to use as value, usually sf_id)
+        static:
+            FieldAPIName: True
+            AnotherFieldAPIName: MonthlyLiteral
+
+Example
+^^^^^^^
+
+.. code-block:: yaml    
+    Insert Organizations:
+        sf_object: Account
+        table: organizations
+        fields:
+            Id: sf_id
+            Name: organization
+        record_type: Organization
 
 
-
-Insert Organizations:
-    sf_object: Account
-    table: organizations
-    fields:
-        Id: sf_id
-        Name: organization
-    record_type: Organization
-
-
-Insert Household Contacts:
-    sf_object: Contact
-    table: contacts
-    filters:
-        - 'household_id is not null'
-    fields:
-        Id: sf_id
-        Salutation: salutation
-        FirstName: first_name
-        LastName: last_name
-        Email: email
-        Phone: phone
-        Title: job_title
-    lookups:
-        AccountId:
-            key_field: household_id
-            table: households
-            join_field: household_id
-            value_field: sf_id
-        Primary_Affiliation__c: 
-            key_field: organization_id
-            table: organizations
-            join_field: organization_id
-            value_field: sf_id
+    Insert Household Contacts:
+        sf_object: Contact
+        table: contacts
+        filters:
+            - 'household_id is not null'
+        fields:
+            Id: sf_id
+            Salutation: salutation
+            FirstName: first_name
+            LastName: last_name
+            Email: email
+            Phone: phone
+            Title: job_title
+        lookups:
+            AccountId:
+                key_field: household_id
+                table: households
+                join_field: household_id
+                value_field: sf_id
+            Primary_Affiliation__c: 
+                key_field: organization_id
+                table: organizations
+                join_field: organization_id
+                value_field: sf_id


### PR DESCRIPTION
closes #525 - if a mapping defines a record_type, when retrieving that sobject, filter by that record type.

additionally fixes a bug where a second mapping on the same sqlite table would not properly add newly mapped fields to the table in retrieve mode.

adds an `api` flag on the mapping, currently doesn't do anything, i can roll that back if you want a clean merge, but eventually it will support loading objects that bulk doesn't.