### PR TITLE
add a sleep between queries

### DIFF
--- a/cumulusci/tasks/salesforce.py
+++ b/cumulusci/tasks/salesforce.py
@@ -1199,6 +1199,7 @@ class PackageUpload(BaseSalesforceApiTask):
                 e = SalesforceException
             raise e('Package upload failed')
         else:
+            time.sleep(5)
             version_id = upload['MetadataPackageVersionId']
             version_res = self.tooling.query("select MajorVersion, MinorVersion, PatchVersion, BuildNumber, ReleaseState from MetadataPackageVersion where Id = '{}'".format(version_id))
             if version_res['totalSize'] != 1:


### PR DESCRIPTION
as of Spring 18 we are seeing a delay in the `MetadataPackageVersion` record being available after the `PackageUploadRequest` reports success. This PR adds a 5 sec sleep, under the assumption that this is now an asynch process on the platform side. Working to confirm that with someone on DX.

closes #548 