### PR TITLE
use tooling API for packageuploadrequest

### DIFF
--- a/cumulusci/tasks/salesforce.py
+++ b/cumulusci/tasks/salesforce.py
@@ -1141,8 +1141,7 @@ class PackageUpload(BaseSalesforceApiTask):
             self.options['namespace'] = self.project_config.project__package__namespace
 
     def _run_task(self):
-        sf = self._init_api()
-        package_res = sf.query("select Id from MetadataPackage where NamespacePrefix='{}'".format(self.options['namespace']))
+        package_res = self.tooling.query("select Id from MetadataPackage where NamespacePrefix='{}'".format(self.options['namespace']))
 
         if package_res['totalSize'] != 1:
             message = 'No package found with namespace {}'.format(self.options['namespace'])

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -367,7 +367,6 @@ To really show the power of CumulusCI, we'll automate the entire process of rele
 * Log into the org
 * Go to Setup -> Packages and create an Unmanaged Package named whatever you want to call your package
 * Assign a namespace to the org and point it at the Unmanaged Package you created
-* Request the `Push API` permission be enabled in your packaging org through Salesforce Partner Support.  The Push API is necessary to use the `release_beta` flow in the example below.
 
 Once you have the org, connect it to `cci`'s project keychain with `cci org connect <org_name>`:
 


### PR DESCRIPTION
the UploadPackage task now uses the Tooling API for all calls, instead of using the Data API to query MetadataPackage. This means UploadPackage no longer requires the Push API permissions.