### PR TITLE
Added support for GlobalValueSetTranslation Metadata Type

### DIFF
--- a/cumulusci/tasks/metadata/metadata_map.yml
+++ b/cumulusci/tasks/metadata/metadata_map.yml
@@ -68,6 +68,10 @@ globalValueSets:
     - type: GlobalValueSet
       class: MetadataFilenameParser
       extension: globalValueSet
+globalValueSetTranslations:
+    - type: GlobalValueSetTranslation
+      class: MetadataFilenameParser
+      extension: globalValueSetTranslation
 homePageComponents:
     - type: HomePageComponent
       class: MetadataFilenameParser


### PR DESCRIPTION
`cci task run update_package_xml` now parses Metadata Type GlobalValueSetTranslations correctly