### PR TITLE
close zip and reopen in read mode before processing

### DIFF
--- a/cumulusci/tasks/salesforce.py
+++ b/cumulusci/tasks/salesforce.py
@@ -352,9 +352,10 @@ class Deploy(BaseSalesforceMetadataApiTask):
         for root, dirs, files in os.walk('.'):
             for f in files:
                 self._write_zip_file(zipf, root, f)
-        zipf = self._process_zip_file(zipf)
-        zipf.fp.seek(0)
-        package_zip = base64.b64encode(zipf.fp.read())
+        zipf.close()
+        zipf_processed = self._process_zip_file(zipfile.ZipFile(zip_file))
+        zipf_processed.fp.seek(0)
+        package_zip = base64.b64encode(zipf_processed.fp.read())
 
         os.chdir(pwd)
 


### PR DESCRIPTION
Fixes #530 

The zip file is opened in write mode, then later read for processing. Closing the zip file after writing, then reopening in read mode before processing fixes the issue.