### PR TITLE
stderr was not being logged on Command failures.

### DIFF
--- a/cumulusci/tasks/command.py
+++ b/cumulusci/tasks/command.py
@@ -88,6 +88,7 @@ class Command(BaseTask):
         p = subprocess.Popen(
             command,
             stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
             bufsize=1,
             shell=True,
             executable='/bin/bash',


### PR DESCRIPTION
Errors encountered when running Command tasks would return `None` for `stderr`.

According to the documentation on `subprocess` (https://docs.python.org/2/library/subprocess.html#popen-constructor) if `stderr` is not set to `subprocess.PIPE` then it will always return `None` and will not actually log the `stderr` stream.