### PR TITLE
Allow user to pass True into pass_env in the Command task

### DIFF
--- a/cumulusci/tasks/command.py
+++ b/cumulusci/tasks/command.py
@@ -41,9 +41,9 @@ class Command(BaseTask):
 
     def _init_options(self, kwargs):
         super(Command, self)._init_options(kwargs)
-        if 'pass_env' not in self.options:
+        if 'pass_env' not in self.options or self.options['pass_env'] == 'True':
             self.options['pass_env'] = True
-        if self.options['pass_env'] == 'False':
+        elif self.options['pass_env'] == 'False':
             self.options['pass_env'] = False
         if 'dir' not in self.options or not self.options['dir']:
             self.options['dir'] = '.'


### PR DESCRIPTION
Users could pass `False` to the `pass_env` option in a `Command` task. It would have the desired result of assigning the `False` boolean value to `self.options['pass_env']`. The default value is `True` and if not provided, the `True` boolean value is assigned as expected.

The unexpected case is that when you explicitly provide `True` to the option, the `True` boolean value was not assigned.

This rectifies that issue.