### PR TITLE
Add the ability to have interactive commands via the Command task.

### DIFF
--- a/cumulusci/tasks/command.py
+++ b/cumulusci/tasks/command.py
@@ -9,6 +9,7 @@ SalesforceBrowserTest - a task designed to wrap browser testing that could
 import json
 import os
 import subprocess
+import sys
 
 from cumulusci.core.exceptions import CommandException
 from cumulusci.core.exceptions import BrowserTestFailure
@@ -38,6 +39,11 @@ class Command(BaseTask):
                            'Defaults to True',
             'required': True,
         },
+        'use_std': {
+            'description': 'If True, the command will use stderr, stdout, '
+                           'and stdin of the main process.'
+                           'Defaults to False.',
+        },
     }
 
     def _init_options(self, kwargs):
@@ -46,6 +52,8 @@ class Command(BaseTask):
             self.options['pass_env'] = True
         if 'dir' not in self.options or not self.options['dir']:
             self.options['dir'] = '.'
+        if 'use_std' not in self.options:
+            self.options['use_std'] = False
         if 'env' not in self.options:
             self.options['env'] = {}
         else:
@@ -83,11 +91,13 @@ class Command(BaseTask):
     def _run_command(self, env, command=None, output_handler=None, return_code_handler=None):
         if not command:
             command = self.options['command']
+        use_std = process_bool_arg(self.options['use_std'])
         self.logger.info('Running command: %s', command)
         p = subprocess.Popen(
             command,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
+            stdout=sys.stdout if use_std else subprocess.PIPE,
+            stderr=sys.stderr if use_std else subprocess.PIPE,
+            stdin=sys.stdin if use_std else subprocess.PIPE,
             bufsize=1,
             shell=True,
             executable='/bin/bash',
@@ -95,12 +105,14 @@ class Command(BaseTask):
             cwd=self.options.get('dir'),
         )
 
-        # Handle output lines
-        if not output_handler:
-            output_handler = self._process_output
-        for line in iter(p.stdout.readline, ''):
-            output_handler(line)
-        p.stdout.close()
+        if not use_std:
+            # Handle output lines
+            if not output_handler:
+                output_handler = self._process_output
+            for line in iter(p.stdout.readline, ''):
+                output_handler(line)
+            p.stdout.close()
+
         p.wait()
         
         # Handle return code

--- a/docs/tasks.rst
+++ b/docs/tasks.rst
@@ -46,6 +46,7 @@ Options:
 * **env**: Environment variables to set for command. Must be flat dict, either as python dict from YAML or as JSON string.
 * **dir**: If provided, the directory where the command should be run from.
 * **pass_env** *(required)*: If False, the current environment variables will not be passed to the child process. Defaults to True
+* **use_std**: If True, the command will use stdout, stderr, and stdin of the main process. Defaults to False
 
 commit_apex_docs
 ==========================================


### PR DESCRIPTION
Needed a way to be able to call out to an interactive shell script during a custom flow. Adding an option to the `Command` class seemed like the cleanest way to accomplish this.