### PR TITLE
Make Command tasks work on Windows

### DIFF
--- a/cumulusci/tasks/command.py
+++ b/cumulusci/tasks/command.py
@@ -100,7 +100,6 @@ class Command(BaseTask):
             stdin=sys.stdin if interactive_mode else subprocess.PIPE,
             bufsize=1,
             shell=True,
-            executable='/bin/bash',
             env=env,
             cwd=self.options.get('dir'),
         )


### PR DESCRIPTION
Fixes #379 

As far as I know there's no reason we need to specify /bin/bash in the Popen command. Removing this allows Windows to use the command task.