### PR TITLE
support nesting flows

### DIFF
--- a/cumulusci/core/flows.py
+++ b/cumulusci/core/flows.py
@@ -175,7 +175,12 @@ class BaseFlow(object):
             self._run_task(flow_task_config)
 
     def _run_flow(self, flow_task_config):
-        flow = BaseFlow(
+        class_path = flow_task_config['task_config'].config.get(
+            'class_path',
+            'cumulusci.core.flows.BaseFlow',
+        )
+        flow_class = import_class(class_path)
+        flow = flow_class(
             self.project_config,
             flow_task_config['task_config'],
             self.org_config,

--- a/cumulusci/core/flows.py
+++ b/cumulusci/core/flows.py
@@ -25,13 +25,10 @@ class BaseFlow(object):
         self.skip = skip
         self.task_options = {}
         self.skip_tasks = []
-        self.task_return_values = []
-        """ A collection of return_values dicts in task execution order """
-        self.task_results = []
-        """ A collection of result objects in task execution order """
-        self.tasks = []
-        """ A collection of configured task objects, either run or failed """
-        self.nested = nested
+        self.task_return_values = []  # A collection of return_values dicts in task execution order
+        self.task_results = []  # A collection of result objects in task execution order
+        self.tasks = []  # A collection of configured task objects, either run or failed
+        self.nested = nested  # indicates if flow is called from another flow
         self._init_options()
         self._init_skip(skip)
         self._init_logger()

--- a/cumulusci/core/flows.py
+++ b/cumulusci/core/flows.py
@@ -100,6 +100,7 @@ class BaseFlow(object):
                 raise ConfigError('"flow" and "task" in same config item')
             if (('flow' in config and config['flow'] == 'None') or
                 ('task' in config and config['task'] == 'None')):
+                # allows skipping flows/tasks using YAML overrides
                 continue
             if 'flow' in config:  # nested flow
                 task_config = self.project_config.get_flow(config['flow'])

--- a/cumulusci/core/flows.py
+++ b/cumulusci/core/flows.py
@@ -8,17 +8,21 @@ from distutils.version import LooseVersion  # pylint: disable=import-error,no-na
 import logging
 import traceback
 
+from cumulusci.core.config import FlowConfig
 from cumulusci.core.config import TaskConfig
+from cumulusci.core.exceptions import ConfigError
 from cumulusci.core.utils import import_class
 
 
 class BaseFlow(object):
     """ BaseFlow handles initializing and running a flow """
 
-    def __init__(self, project_config, flow_config, org_config, options=None, skip=None):
+    def __init__(self, project_config, flow_config, org_config, options=None, skip=None, nested=False):
         self.project_config = project_config
         self.flow_config = flow_config
         self.org_config = org_config
+        self.options = options
+        self.skip = skip
         self.task_options = {}
         self.skip_tasks = []
         self.task_return_values = []
@@ -27,15 +31,16 @@ class BaseFlow(object):
         """ A collection of result objects in task execution order """
         self.tasks = []
         """ A collection of configured task objects, either run or failed """
-        self._init_options(options)
+        self.nested = nested
+        self._init_options()
         self._init_skip(skip)
         self._init_logger()
         self._init_flow()
 
-    def _init_options(self, options):
-        if not options:
+    def _init_options(self):
+        if not self.options:
             return
-        for key, value in list(options.items()):
+        for key, value in list(self.options.items()):
             task, option = key.split('__')
             if task not in self.task_options:
                 self.task_options[task] = {}
@@ -72,26 +77,46 @@ class BaseFlow(object):
         self.logger.info('---------------------------------------')
 
         self.logger.info('')
-        self._init_org()
+        if not self.nested:
+            self._init_org()
         for line in self._render_config():
             self.logger.info(line)
 
+    def _check_infinite_flows(self, tasks, flows=None):
+        if flows == None:
+            flows = []
+        for task in tasks.values():
+            if 'flow' in task:
+                flow = task['flow']
+                if flow in flows:
+                    raise ConfigError('Infinite flows detected')
+                flows.append(flow)
+                flow_config = self.project_config.get_flow(flow)
+                self._check_infinite_flows(flow_config.tasks, flows)
+
     def _get_tasks(self):
+        if not self.nested:
+            self._check_infinite_flows(self.flow_config.tasks)
         tasks = []
         for step_num, config in list(self.flow_config.tasks.items()):
-            if config['task'] == 'None':
+            if 'flow' in config and 'task' in config:
+                raise ConfigError('"flow" and "task" in same config item')
+            if (('flow' in config and config['flow'] == 'None') or
+                ('task' in config and config['task'] == 'None')):
                 continue
+            if 'flow' in config:  # nested flow
+                task_config = self.project_config.get_flow(config['flow'])
+            elif 'task' in config:
+                task_config = self.project_config.get_task(config['task'])
             tasks.append((
                 LooseVersion(str(step_num)),
                 {
                     'flow_config': config,
-                    'task_config': self.project_config.get_task(
-                        config['task']
-                    ),
+                    'task_config': task_config,
                 }
             ))
-        tasks.sort()
-        tasks = [task_info[1] for task_info in tasks]
+        tasks.sort()  # sort by step number
+        tasks = [task[1] for task in tasks]  # drop the sort keys
         return tasks
 
     def _render_config(self):
@@ -105,13 +130,17 @@ class BaseFlow(object):
 
         config.append('Tasks:')
         for task_info in self._get_tasks():
-            skipped = ''
-            if task_info['flow_config']['task'] in self.skip_tasks:
-                skipped = '[SKIPPED] '
+            if 'flow' in task_info['flow_config']:
+                task = task_info['flow_config']['flow']
+                flow = '(Flow) '
+            elif 'task' in task_info['flow_config']:
+                task = task_info['flow_config']['task']
+                flow = ''
 
-            config.append('  {}{}: {}'.format(
-                skipped,
-                task_info['flow_config']['task'],
+            config.append('  {}{}{}: {}'.format(
+                '[SKIPPED] ' if task in self.skip_tasks else '',
+                flow,
+                task,
                 task_info['task_config'].description,
             ))
 
@@ -126,7 +155,7 @@ class BaseFlow(object):
 
     def __call__(self):
         for flow_task_config in self._get_tasks():
-            self._run_task(flow_task_config)
+            self._run_step(flow_task_config)
 
     def _find_task_by_name(self, name):
         if not self.flow_config.tasks:
@@ -134,10 +163,27 @@ class BaseFlow(object):
 
         i = 0
         for task in self._get_tasks():
-            if task['flow_config']['task'] == name:
+            if 'task' in task['flow_config'] and task['flow_config']['task'] == name:
                 if len(self.tasks) > i:
                     return self.tasks[i]
             i += 1
+
+    def _run_step(self, flow_task_config):
+        if isinstance(flow_task_config['task_config'], FlowConfig):
+            self._run_flow(flow_task_config)
+        elif isinstance(flow_task_config['task_config'], TaskConfig):
+            self._run_task(flow_task_config)
+
+    def _run_flow(self, flow_task_config):
+        flow = BaseFlow(
+            self.project_config,
+            flow_task_config['task_config'],
+            self.org_config,
+            options=self.options,
+            skip=self.skip,
+            nested=True,
+        )
+        flow()
 
     def _run_task(self, flow_task_config):
         task_config = copy.deepcopy(flow_task_config['task_config'].config)

--- a/cumulusci/core/tests/test_flows.py
+++ b/cumulusci/core/tests/test_flows.py
@@ -85,6 +85,12 @@ class TestBaseFlow(unittest.TestCase):
                     'cumulusci.core.tests.test_flows._SfdcTask'
             },
         }
+        self.project_config.config['flows'] = {
+            'nested_flow': {
+                'description': 'A flow that runs inside another flow',
+                'tasks': {1: {'task': 'pass_name'}},
+            },
+        }
         self.org_config = OrgConfig({
             'username': 'sample@example',
             'org_id': ORG_ID
@@ -419,3 +425,15 @@ class TestBaseFlow(unittest.TestCase):
         org_id_logs = [s for s in self.flow_log['info'] if ORG_ID in s]
 
         self.assertEqual(1, len(org_id_logs))
+
+    def test_nested_flow(self, mock_class):
+        """ Flows can run inside other flows """
+        flow_config = FlowConfig({
+            'description': 'Run a task and a flow',
+            'tasks': {
+                1: {'task': 'pass_name'},
+                2: {'flow': 'nested_flow'},
+            },
+        })
+        flow = BaseFlow(self.project_config, flow_config, self.org_config)
+        flow()

--- a/cumulusci/core/tests/test_flows.py
+++ b/cumulusci/core/tests/test_flows.py
@@ -88,7 +88,16 @@ class TestBaseFlow(unittest.TestCase):
         self.project_config.config['flows'] = {
             'nested_flow': {
                 'description': 'A flow that runs inside another flow',
-                'tasks': {1: {'task': 'pass_name'}},
+                'tasks': {
+                    1: {'task': 'pass_name'},
+                },
+            },
+            'nested_flow_2': {
+                'description': 'A flow that runs inside another flow, and calls another flow',
+                'tasks': {
+                    1: {'task': 'pass_name'},
+                    2: {'flow': 'nested_flow'},
+                },
             },
         }
         self.org_config = OrgConfig({
@@ -437,3 +446,29 @@ class TestBaseFlow(unittest.TestCase):
         })
         flow = BaseFlow(self.project_config, flow_config, self.org_config)
         flow()
+        self.assertEqual(2, len(flow.tasks))
+        self.assertEqual(
+            flow.task_return_values[0],
+            flow.task_return_values[1][0],
+        )
+
+    def test_nested_flow_2(self, mock_class):
+        """ Flows can run inside other flows and call other flows """
+        flow_config = FlowConfig({
+            'description': 'Run a task and a flow',
+            'tasks': {
+                1: {'task': 'pass_name'},
+                2: {'flow': 'nested_flow_2'},
+            },
+        })
+        flow = BaseFlow(self.project_config, flow_config, self.org_config)
+        flow()
+        self.assertEqual(2, len(flow.tasks))
+        self.assertEqual(
+            flow.task_return_values[0],
+            flow.task_return_values[1][0],
+        )
+        self.assertEqual(
+            flow.task_return_values[0],
+            flow.task_return_values[1][1][0],
+        )


### PR DESCRIPTION
Allow flows to call other flows. Example usage in `cumulusci.yml`:

```
flows:
    example_flow:
        tasks:
            1:
                task: example_task
            2:
                flow: another_flow
```

- A given flow may only occur once in the tree, to prevent infinite recursion
- Nested flows inherit the project config, org config, flow options, and skipped tasks from parent flows
- Return values from nested flows can be referenced just like tasks: flow1.flow2.task.key