### PR TITLE
get 100 PRs per page instead of 30

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,14 @@
 History
 =======
 
+2.0.0-beta93 (2018-04-20)
+-------------------------
+
+- Fix issue in command task for Windows
+- Support interactive in command task (thanks Chris Landry!)
+- Search more pull requests (100 vs 30) when generating release notes
+- Add options to Apex documentation generator task
+
 2.0.0-beta92 (2018-04-04)
 -------------------------
 

--- a/cumulusci/__init__.py
+++ b/cumulusci/__init__.py
@@ -1,5 +1,5 @@
 from __future__ import unicode_literals
 import os
 __import__('pkg_resources').declare_namespace('cumulusci')
-__version__ = '2.0.0-beta92'
+__version__ = '2.0.0-beta93'
 __location__ = os.path.dirname(os.path.realpath(__file__))

--- a/cumulusci/tasks/release_notes/provider.py
+++ b/cumulusci/tasks/release_notes/provider.py
@@ -188,7 +188,7 @@ class GithubChangeNotesProvider(BaseChangeNotesProvider, ProviderGithubApiMixin)
         date merged search """
         try:
             pull_requests = self.call_api(
-                '/pulls?state=closed&base={}'.format(self.master_branch)
+                '/pulls?page=1&per_page=100&state=closed&base={}'.format(self.master_branch)
             )
         except GithubApiNoResultsError:
             pull_requests = []

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,7 +2,7 @@
 build-base=pybuild
 
 [bumpversion]
-current_version = 2.0.0-beta92
+current_version = 2.0.0-beta93
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ test_requirements = [
 
 setup(
     name='cumulusci',
-    version='2.0.0-beta92',
+    version='2.0.0-beta93',
     description="Build and release tools for Salesforce developers",
     long_description=readme + '\n\n' + history,
     author="Jason Lantz",


### PR DESCRIPTION
Fixes #608 

Working on a better solution that uses github3.py instead of directly calling the API in the release notes task, but wanted to fix this in the meantime since it is causing issues in our release notes. 100 is the max results per page.