### PR TITLE
add dev_deploy flow

### DIFF
--- a/cumulusci/cumulusci.yml
+++ b/cumulusci/cumulusci.yml
@@ -277,6 +277,15 @@ flows:
                 task: generate_apex_docs
             2:
                 task: commit_apex_docs
+                
+    dev_deploy:
+        description: Unschedule apex and deploy the latest unmanaged metadata.
+        tasks:
+            1:
+                task: unschedule_apex
+            2:
+                task: deploy
+
     dev_org:
         description: Deploys the unmanaged package metadata and all dependencies to the target org
         tasks:


### PR DESCRIPTION
adds a flow to just run unschedule_jobs and deploy, for when you've pulled down some updates on a shared branch and know you don't need to update deps or any of that other stuff...