### PR TITLE
Better error message for running a flow without a default org.

### DIFF
--- a/cumulusci/cli/cci.py
+++ b/cumulusci/cli/cci.py
@@ -1023,6 +1023,9 @@ def flow_run(config, flow_name, org, delete_org, debug, o, skip, no_prompt):
         org_config = config.project_config.get_org(org)
     else:
         org, org_config = config.project_config.keychain.get_default_org()
+        if org_config is None:
+          raise click.UsageError(
+            'No org specified and no default org set.')
 
     org_config = check_org_expired(config, org, org_config)
     


### PR DESCRIPTION
I've run into this a few times now where I run a flow thinking I have set a default org, but I haven't. The stack trace that's output is relatively unhelpful, so let's replace it with something more user friendly.