### PR TITLE
Fixing issue where new orgs made with flow have stale passwords in org info.

### DIFF
--- a/cumulusci/core/flows.py
+++ b/cumulusci/core/flows.py
@@ -57,7 +57,16 @@ class BaseFlow(object):
         """ Refresh the token on the org """
         self.logger.info('Verifying and refreshing credentials for target org {}'.format(self.org_config.name))
         orig_config = self.org_config.config.copy()
+
+        if not self.org_config.created:
+          self.project_config.keychain.create_scratch_org(
+            self.org_config.name,
+            self.org_config.config_name,
+            self.org_config.days,
+            set_password=True)
+
         self.org_config.refresh_oauth_token(self.project_config.keychain)
+          
         if self.org_config.config != orig_config:
             self.logger.info('Org info has changed, updating org in keychain')
             self.project_config.keychain.set_org(self.org_config)


### PR DESCRIPTION
Fixes https://github.com/SalesforceFoundation/CumulusCI/issues/641

Stale passwords were being shown in `cci org info` after a flow created a new org when it found none. Fixed this by specifying creation options on the org when a flow is executed and finds an org hasn't been created.

Unlike `cci org scratch dev org_name` I am not providing an option to not set a password, although this is an option that could be added in the future.