### PR TITLE
Py3 Compats & Some Miscellaney

### DIFF
--- a/cumulusci/cli/cci.py
+++ b/cumulusci/cli/cci.py
@@ -1026,7 +1026,7 @@ def flow_run(config, flow_name, org, delete_org, debug, o, skip, no_prompt):
     # Create the flow and handle initialization exceptions
     try:
         flow = flow_class(config.project_config, flow_config,
-                          org_config, options, skip)
+                          org_config, options, skip, name=flow_name)
     except TaskRequiresSalesforceOrg as e:
         exception = click.UsageError(
             'This flow requires a salesforce org.  Use org default <name> to set a default org or pass the org name with the --org option')

--- a/cumulusci/cli/cci.py
+++ b/cumulusci/cli/cci.py
@@ -359,7 +359,7 @@ def project_init(config, extend):
         elif selection == '2':
             dependencies.append({'type': 'github', 'url': 'https://github.com/SalesforceFoundation/Cumulus'})
         else:
-            print selection
+            print(selection)
             github_url = click.prompt(click.style('Enter the Github Repository URL', bold=True))
             dependencies.append({'type': 'github', 'url': github_url})
     context['dependencies'] = dependencies

--- a/cumulusci/cli/cci.py
+++ b/cumulusci/cli/cci.py
@@ -830,7 +830,8 @@ def task_info(config, task_name):
         raise TaskNotFoundError('Task not found: {}'.format(task_name))
 
     task_config = TaskConfig(task_config)
-    click.echo(rst2ansi(doc_task(task_name, task_config)))
+    doc = doc_task(task_name, task_config).encode()
+    click.echo(rst2ansi(doc))
 
 
 @click.command(name='run', help="Runs a task")

--- a/cumulusci/core/exceptions.py
+++ b/cumulusci/core/exceptions.py
@@ -99,6 +99,10 @@ class FlowNotFoundError(CumulusCIException):
     """ Raise when flow is not found in project config """
     pass
 
+class FlowNotReadyError(CumulusCIException):
+    """ Raise when flow is called before it has been prepared """
+    pass
+
 
 class MrbelvedereError(CumulusCIException):
     """ Raise for errors from mrbelvedere installer """

--- a/cumulusci/core/flows.py
+++ b/cumulusci/core/flows.py
@@ -18,7 +18,7 @@ class BaseFlow(object):
     """ BaseFlow handles initializing and running a flow """
 
     def __init__(self, project_config, flow_config, org_config, options=None, skip=None, nested=False):
-        self.project_config = project_config
+        self.project_config = project_config # a subclass of BaseTaskFlowConfig, tho tasks may expect more than that
         self.flow_config = flow_config
         self.org_config = org_config
         self.options = options
@@ -179,11 +179,9 @@ class BaseFlow(object):
             self._run_task(stepnum, flow_task_config)
 
     def _run_flow(self, stepnum, flow_task_config):
-        class_path = flow_task_config['task_config'].config.get(
-            'class_path',
-            'cumulusci.core.flows.BaseFlow',
-        )
-        flow_class = import_class(class_path)
+        flow_class = self.__class__
+        if 'class_path' in flow_task_config['task_config'].config:
+            flow_class = import_class(flow_task_config['task_config'].config['class_path'])
         flow = flow_class(
             self.project_config,
             flow_task_config['task_config'],

--- a/cumulusci/core/flows.py
+++ b/cumulusci/core/flows.py
@@ -159,10 +159,18 @@ class BaseFlow(object):
         return config
 
     def __call__(self):
+        self._pre_flow()
         if not self.prepped:
             raise FlowNotReadyError('Flow executed before init_flow was called')
         for stepnum, flow_task_config in self._get_tasks_ordered():
             self._run_step(stepnum, flow_task_config)
+        self._post_flow()
+
+    def _pre_flow(self):
+        pass
+    
+    def _post_flow(self):
+        pass
 
     def _find_task_by_name(self, name):
         if not self.flow_config.tasks:
@@ -198,7 +206,9 @@ class BaseFlow(object):
             nested=True,
             parent=self
         )
+        self._pre_subflow(flow)
         flow()
+        self._post_subflow(flow)
         self.tasks.append(flow)
         self.task_return_values.append(flow.task_return_values)
 
@@ -243,6 +253,12 @@ class BaseFlow(object):
         pass
 
     def _post_task_exception(self, task, exception):
+        pass
+
+    def _pre_subflow(self, flow):
+        pass
+
+    def _post_subflow(self, flow):
         pass
 
     def _get_task(self, stepnum, flow_task_config):

--- a/cumulusci/core/flows.py
+++ b/cumulusci/core/flows.py
@@ -18,17 +18,17 @@ class BaseFlow(object):
     """ BaseFlow handles initializing and running a flow """
 
     def __init__(
-        self,
-        project_config,
-        flow_config,
-        org_config,
-        options=None,
-        skip=None,
-        nested=False,
-        parent=None,
-        prep=True,
-        name=None,
-        stepnum=None
+            self,
+            project_config,
+            flow_config,
+            org_config,
+            options=None,
+            skip=None,
+            nested=False,
+            parent=None,
+            prep=True,
+            name=None,
+            stepnum=None
     ):
         self.project_config = project_config # a subclass of BaseTaskFlowConfig, tho tasks may expect more than that
         self.flow_config = flow_config
@@ -44,6 +44,7 @@ class BaseFlow(object):
         self.parent = parent # parent flow, if nested
         self.name = name # the flows name.
         self.stepnum = stepnum # a nested flow has a stepnum
+        self._skip_next = False # internal only control flow option for subclasses to override a step execution in their pre.
         self._init_options()
         self._init_skip(skip)
         self._init_logger()
@@ -225,6 +226,11 @@ class BaseFlow(object):
             stepnum=stepnum
         )
         self._pre_subflow(flow)
+        
+        if self._skip_next:
+            self._skip_next = False
+            return
+
         flow()
         self._post_subflow(flow)
         self.tasks.append(flow)
@@ -249,6 +255,9 @@ class BaseFlow(object):
         self.logger.info('')
         self.logger.info('Running task: %s', task.name)
         self._pre_task(task)
+        if self._skip_next:
+            self._skip_next = False
+            return
         try:
             task()
             self.logger.info('Task complete: %s', task.name)

--- a/cumulusci/core/flows.py
+++ b/cumulusci/core/flows.py
@@ -17,7 +17,7 @@ from cumulusci.core.utils import import_class
 class BaseFlow(object):
     """ BaseFlow handles initializing and running a flow """
 
-    def __init__(self, project_config, flow_config, org_config, options=None, skip=None, nested=False):
+    def __init__(self, project_config, flow_config, org_config, options=None, skip=None, nested=False, parent=None):
         self.project_config = project_config # a subclass of BaseTaskFlowConfig, tho tasks may expect more than that
         self.flow_config = flow_config
         self.org_config = org_config
@@ -29,6 +29,7 @@ class BaseFlow(object):
         self.task_results = []  # A collection of result objects in task execution order
         self.tasks = []  # A collection of configured task objects, either run or failed
         self.nested = nested  # indicates if flow is called from another flow
+        self.parent = parent # parent flow, if nested
         self._init_options()
         self._init_skip(skip)
         self._init_logger()
@@ -189,6 +190,7 @@ class BaseFlow(object):
             options=self.options,
             skip=self.skip,
             nested=True,
+            parent=self
         )
         flow()
         self.tasks.append(flow)

--- a/cumulusci/core/flows.py
+++ b/cumulusci/core/flows.py
@@ -27,7 +27,8 @@ class BaseFlow(object):
         nested=False,
         parent=None,
         prep=True,
-        name=None
+        name=None,
+        stepnum=None
     ):
         self.project_config = project_config # a subclass of BaseTaskFlowConfig, tho tasks may expect more than that
         self.flow_config = flow_config
@@ -42,6 +43,7 @@ class BaseFlow(object):
         self.nested = nested  # indicates if flow is called from another flow
         self.parent = parent # parent flow, if nested
         self.name = name # the flows name.
+        self.stepnum = stepnum # a nested flow has a stepnum
         self._init_options()
         self._init_skip(skip)
         self._init_logger()
@@ -219,7 +221,8 @@ class BaseFlow(object):
             skip=self.skip,
             nested=True,
             parent=self,
-            name=flow_task_config['flow_config']['flow']
+            name=flow_task_config['flow_config']['flow'],
+            stepnum=stepnum
         )
         self._pre_subflow(flow)
         flow()

--- a/cumulusci/cumulusci.yml
+++ b/cumulusci/cumulusci.yml
@@ -269,7 +269,7 @@ tasks:
         options:
             seconds: 5
 
-    info:
+    log:
         description: Log a line at the info level.
         class_path: cumulusci.tasks.util.LogLine
         options:

--- a/cumulusci/cumulusci.yml
+++ b/cumulusci/cumulusci.yml
@@ -269,6 +269,12 @@ tasks:
         options:
             seconds: 5
 
+    info:
+        description: Log a line at the info level.
+        class_path: cumulusci.tasks.util.LogLine
+        options:
+            level: info
+
 flows:
     apex_docs:
         description: Generate and commit documentation using ApexDoc

--- a/cumulusci/oauth/salesforce.py
+++ b/cumulusci/oauth/salesforce.py
@@ -116,7 +116,7 @@ class CaptureSalesforceOAuth(object):
         url = self._get_redirect_url()
         self._launch_browser(url)
         self._create_httpd()
-        print (
+        print(
             'Spawning HTTP server at {} '.format(self.callback_url) +
             'with timeout of {} seconds.\n'.format(self.httpd.timeout) +
             'If you are unable to log in to Salesforce you can ' +

--- a/cumulusci/tasks/command.py
+++ b/cumulusci/tasks/command.py
@@ -65,7 +65,7 @@ class Command(BaseTask):
 
     def _run_task(self):
         env = self._get_env()
-        self._run_command(env)
+        #self._run_command(env)
 
     def _get_env(self):
         if process_bool_arg(self.options['pass_env']):

--- a/cumulusci/tasks/command.py
+++ b/cumulusci/tasks/command.py
@@ -65,7 +65,7 @@ class Command(BaseTask):
 
     def _run_task(self):
         env = self._get_env()
-        #self._run_command(env)
+        self._run_command(env)
 
     def _get_env(self):
         if process_bool_arg(self.options['pass_env']):

--- a/cumulusci/tasks/release_notes/tests/test_generator.py
+++ b/cumulusci/tasks/release_notes/tests/test_generator.py
@@ -84,9 +84,9 @@ class TestDirectoryReleaseNotesGenerator(unittest.TestCase):
 
         content = release_notes()
         expected = "# Critical Changes\r\n\r\n* This will break everything!\r\n\r\n# Changes\r\n\r\nHere's something I did. It was really cool\r\nOh yeah I did something else too!\r\n\r\n# Issues Closed\r\n\r\n#2345\r\n#6236"
-        print expected
-        print '-------------------------------------'
-        print content
+        print(expected)
+        print('-------------------------------------')
+        print(content)
 
         self.assertEqual(content, expected)
 

--- a/cumulusci/tasks/salesforce/RetrieveReportsAndDashboards.py
+++ b/cumulusci/tasks/salesforce/RetrieveReportsAndDashboards.py
@@ -72,7 +72,7 @@ class RetrieveReportsAndDashboards(BaseRetrieveMetadata):
 
         api_version = self.project_config.project__package__api_version
         package_xml = package_xml_from_dict(items, api_version)
-        print package_xml
+        print(package_xml)
         return self.api_class(
             self,
             package_xml,

--- a/cumulusci/tasks/tests/test_sfdx.py
+++ b/cumulusci/tasks/tests/test_sfdx.py
@@ -107,6 +107,6 @@ class TestSFDXBaseTask(unittest.TestCase):
             pass
 
         env = task._get_env()
-        print env
+        print(env)
         self.assertEquals(env.get('SFDX_USERNAME'), 'test access token')
         self.assertEquals(env.get('SFDX_INSTANCE_URL'), 'test instance url')

--- a/cumulusci/tasks/util.py
+++ b/cumulusci/tasks/util.py
@@ -214,6 +214,32 @@ class CopyFile(BaseTask):
     def _run_task(self):
         self.logger.info('Copying file {src} to {dest}'.format(**self.options))
         shutil.copyfile(
-            src = self.options['src'],
-            dst = self.options['dest'],
+            src=self.options['src'],
+            dst=self.options['dest'],
         )
+
+
+class LogLine(BaseTask):
+    task_options = {
+        'level': {
+            'description': 'The logger level to use',
+            'required': True
+        },
+        'line': {
+            'description': 'A formatstring like line to log',
+            'required': True
+        },
+        'format_vars': {
+            'description': 'A Dict of format vars',
+            'required': False
+        }
+    }
+
+    def _init_options(self, kwargs):
+        super(LogLine, self)._init_options(kwargs)
+        if 'format_vars' not in self.options:
+            self.options['format_vars'] = {}
+
+    def _run_task(self):
+        log = getattr(self.logger, self.options['level'])
+        log(self.options['line'].format(**self.options['format_vars']))

--- a/cumulusci/tasks/util.py
+++ b/cumulusci/tasks/util.py
@@ -243,3 +243,23 @@ class LogLine(BaseTask):
     def _run_task(self):
         log = getattr(self.logger, self.options['level'])
         log(self.options['line'].format(**self.options['format_vars']))
+
+class PassOptionAsResult(BaseTask):
+    task_options = {
+        'result': {
+            'description': 'The result for the task',
+            'required': True
+        }
+    }
+
+    def _run_task(self):
+        return self.options['result']
+
+class PassOptionAsReturnValue(BaseTask):
+    task_options = {
+        'key':{'required': True, 'description': 'The return value key to use.'},
+        'value':{'required': True, 'description': 'The value to set.'}
+    }
+
+    def _run_task(self):
+        self.return_values[self.options['key']] = self.options['value']

--- a/cumulusci/tasks/util.py
+++ b/cumulusci/tasks/util.py
@@ -5,7 +5,7 @@ import glob
 from xml.dom.minidom import parse
 
 from cumulusci.core.tasks import BaseTask
-from cumulusci.utils import download_extract_zip
+from cumulusci.utils import download_extract_zip, findReplace, findReplaceRegex
 
 
 class DownloadZip(BaseTask):
@@ -90,6 +90,7 @@ class Sleep(BaseTask):
         time.sleep(float(self.options['seconds']))
         self.logger.info('Done')
 
+
 class Delete(BaseTask):
     name = 'Delete'
     task_options = {
@@ -116,8 +117,8 @@ class Delete(BaseTask):
             for path_item in path:
                 for match in glob.glob(path_item):
                     self._delete(match)
-   
-        if chdir: 
+
+        if chdir:
             os.chdir(cwd)
 
     def _delete(self, path):
@@ -159,8 +160,9 @@ class FindReplace(BaseTask):
             'description': "The max number of matches to replace.  Defaults to replacing all matches.",
         },
     }
-    
-    def _init_options(self):
+
+    def _init_options(self, kwargs):
+        super(FindReplace, self)._init_options(kwargs)
         if 'replace' not in self.options:
             self.options['replace'] = ''
         if 'file_pattern' not in self.options:
@@ -171,28 +173,31 @@ class FindReplace(BaseTask):
         if 'max' in self.options:
             kwargs['max'] = self.options['max']
         findReplace(
-            find = self.options['find'],
-            replace = self.options['replace'],
-            directory = self.options['path'],
-            filePattern = self.options['file_pattern'],
-            logger = self.logger,
+            find=self.options['find'],
+            replace=self.options['replace'],
+            directory=self.options['path'],
+            filePattern=self.options['file_pattern'],
+            logger=self.logger,
             **kwargs
         )
+
 
 find_replace_regex_options = FindReplace.task_options.copy()
 del find_replace_regex_options['max']
 
+
 class FindReplaceRegex(FindReplace):
     task_options = find_replace_regex_options
-            
+
     def _run_task(self):
         findReplaceRegex(
-            find = self.options['find'],
-            replace = self.options['replace'],
-            directory = self.options['path'],
-            filePattern = self.options['file_pattern'],
-            logger = self.logger,
+            find=self.options['find'],
+            replace=self.options['replace'],
+            directory=self.options['path'],
+            filePattern=self.options['file_pattern'],
+            logger=self.logger,
         )
+
 
 class CopyFile(BaseTask):
     task_options = {

--- a/setup.py
+++ b/setup.py
@@ -92,6 +92,6 @@ setup(
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
     ],
-    test_suite='tests',
+    test_suite='cumulusci.core.tests',
     tests_require=test_requirements
 )

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ requirements = [
 test_requirements = [
     'coverage==4.1',
     'coveralls==1.2.0',
-    'flake8==2.6.0'
+    'flake8==2.6.0',
     'mock==2.0.0',
     'nose==1.3.7',
     'nose-tap==1.9',


### PR DESCRIPTION
Like I mentioned, over the weekend I worked on this megabranch. I can split it up into smaller PRs but it's just a few small things. Make sure to review with ?w=1.
- Replace all print statements w/ print() calls and change one encoding method.
- Various fixes that Py3 work revealed: fix some imports for util tasks, weirdness w/ setup script.
- Adds three new utility task classes: PassOptionAsResult, PassOptionAsReturnValue, LogLine
- Flow executions (inner or outer) now know their flow name, and inner flows now know their step number.
- Adds pre-/post- hooks for flow & subflow executions.
- Add a `prep` argument to skip _init_flow when instantiating a flow class. The flow cannot execute til it is `prepped`.
- Sub-flow executions will use the same flow runner class as their parent flow if a flow class is not specified. 