### PR TITLE
Support Dependency on a Private Github repo in unmanaged mode

### DIFF
--- a/cumulusci/cli/cci.py
+++ b/cumulusci/cli/cci.py
@@ -502,6 +502,8 @@ def project_dependencies(config):
     check_project_config(config)
     dependencies = config.project_config.get_static_dependencies()
     for line in config.project_config.pretty_dependencies(dependencies):
+        if line.startswith('    headers:'):
+            continue
         click.echo(line)
 
 

--- a/cumulusci/core/config/BaseProjectConfig.py
+++ b/cumulusci/core/config/BaseProjectConfig.py
@@ -482,6 +482,10 @@ class BaseProjectConfig(BaseTaskFlowConfig):
             repo_name = repo_name[:-4]
         repo = gh.repository(repo_owner, repo_name)
 
+        # Prepare HTTP auth header for requests calls to Github
+        github = self.keychain.get_service('github')
+        headers = {'Authorization': 'token {}'.format(github.password)}
+
         # Determine the ref if specified
         kwargs = {}
         if 'tag' in dependency:
@@ -516,6 +520,7 @@ class BaseProjectConfig(BaseTaskFlowConfig):
                 unpackaged_pre.append({
                     'zip_url': zip_url,
                     'subfolder': subfolder,
+                    'headers': headers,
                     'unmanaged': dependency.get('unmanaged'),
                     'namespace_tokenize': dependency.get('namespace_tokenize'),
                     'namespace_inject': dependency.get('namespace_inject'),
@@ -534,6 +539,7 @@ class BaseProjectConfig(BaseTaskFlowConfig):
                 unmanaged_src = {
                     'zip_url': zip_url,
                     'subfolder': subfolder,
+                    'headers': headers,
                     'unmanaged': dependency.get('unmanaged'),
                     'namespace_tokenize': dependency.get('namespace_tokenize'),
                     'namespace_inject': dependency.get('namespace_inject'),
@@ -555,6 +561,7 @@ class BaseProjectConfig(BaseTaskFlowConfig):
                 dependency = {
                     'zip_url': zip_url,
                     'subfolder': subfolder,
+                    'headers': headers,
                     'unmanaged': dependency.get('unmanaged'),
                     'namespace_tokenize': dependency.get('namespace_tokenize'),
                     'namespace_inject': dependency.get('namespace_inject'),

--- a/cumulusci/tasks/salesforce/UpdateDependencies.py
+++ b/cumulusci/tasks/salesforce/UpdateDependencies.py
@@ -48,6 +48,8 @@ class UpdateDependencies(BaseSalesforceMetadataApiTask):
 
         self.logger.info('Dependencies:')
         for line in self.project_config.pretty_dependencies(dependencies):
+            if line.startswith('    headers:'):
+                continue
             self.logger.info(line)
 
         self._process_dependencies(dependencies)
@@ -153,7 +155,8 @@ class UpdateDependencies(BaseSalesforceMetadataApiTask):
             ))
             package_zip = download_extract_zip(
                 dependency['zip_url'],
-                subfolder=dependency.get('subfolder')
+                subfolder=dependency.get('subfolder'),
+                headers=dependency.get('headers', {}),
             )
             if dependency.get('namespace_tokenize'):
                 self.logger.info('Replacing namespace prefix {}__ in files and filenames with namespace token strings'.format(

--- a/cumulusci/utils.py
+++ b/cumulusci/utils.py
@@ -105,9 +105,10 @@ def remove_xml_element(name, tree):
 
     return tree
 
-
-def download_extract_zip(url, target=None, subfolder=None):
-    resp = requests.get(url)
+def download_extract_zip(url, target=None, subfolder=None, headers=None):
+    if not headers:
+        headers = {}
+    resp = requests.get(url, headers=headers)
     zip_content = io.BytesIO(resp.content)
     zip_file = zipfile.ZipFile(zip_content)
     if subfolder:


### PR DESCRIPTION
If a project has a github dependency to a repo without a namespace
configured or if the dependency has the unmanaged option set, pass the
Github authentication from the github service in a header to allow
depending on an unmanaged private repository.

Fixes #643 