### PR TITLE
beta99

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,11 @@
 History
 =======
 
+2.0.0-beta99 (2018-05-31)
+-------------------------
+
+* Ensure that github credentials are never shown in the log for github dependencies with unmanaged metadata
+
 2.0.0-beta98 (2018-05-31)
 -------------------------
 **WARNING: This release introduces breaking changes to the syntax for flow definitions and to the default flows.  If you customized any of the default flows in your project or have defined custom flows, you will need to modify your cumulusci.yml file to work with this release.**

--- a/cumulusci/__init__.py
+++ b/cumulusci/__init__.py
@@ -1,5 +1,5 @@
 from __future__ import unicode_literals
 import os
 __import__('pkg_resources').declare_namespace('cumulusci')
-__version__ = '2.0.0-beta98'
+__version__ = '2.0.0-beta99'
 __location__ = os.path.dirname(os.path.realpath(__file__))

--- a/cumulusci/cli/cci.py
+++ b/cumulusci/cli/cci.py
@@ -502,7 +502,7 @@ def project_dependencies(config):
     check_project_config(config)
     dependencies = config.project_config.get_static_dependencies()
     for line in config.project_config.pretty_dependencies(dependencies):
-        if line.startswith('    headers:'):
+        if ' headers:' in line:
             continue
         click.echo(line)
 

--- a/cumulusci/core/flows.py
+++ b/cumulusci/core/flows.py
@@ -235,7 +235,7 @@ class BaseFlow(object):
             'class_path',
             'cumulusci.core.flows.BaseFlow',
         )
-        flow_options = step_config['flow_config'].config.get(
+        flow_options = step_config['step_config'].get(
             'options',
             {},
         )

--- a/cumulusci/tasks/salesforce/UpdateDependencies.py
+++ b/cumulusci/tasks/salesforce/UpdateDependencies.py
@@ -48,7 +48,7 @@ class UpdateDependencies(BaseSalesforceMetadataApiTask):
 
         self.logger.info('Dependencies:')
         for line in self.project_config.pretty_dependencies(dependencies):
-            if line.startswith('    headers:'):
+            if ' headers:' in line:
                 continue
             self.logger.info(line)
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,7 +2,7 @@
 build-base=pybuild
 
 [bumpversion]
-current_version = 2.0.0-beta98
+current_version = 2.0.0-beta99
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ test_requirements = [
 
 setup(
     name='cumulusci',
-    version='2.0.0-beta98',
+    version='2.0.0-beta99',
     description="Build and release tools for Salesforce developers",
     long_description=readme + '\n\n' + history,
     author="Jason Lantz",


### PR DESCRIPTION
Depending on the dict key ordering created a situation where dependencies to unmanaged metadata in github would show the headers and the github credential if the headers key happened to be first in the keys list.