### PR TITLE
Wait for Aura XHRs after clicks

### DIFF
--- a/cumulusci/robotframework/Salesforce.robot
+++ b/cumulusci/robotframework/Salesforce.robot
@@ -12,7 +12,7 @@ ${DEBUG}            ${false}
 ${CHROME_BINARY}    ${empty}
 ${ORG}              ${empty}
 ${IMPLICIT_WAIT}    7.0
-${TIMEOUT}          7.0
+${TIMEOUT}          30.0
 
 *** Keywords ***
 
@@ -27,7 +27,6 @@ Open Test Browser
     ...    ELSE IF  '${BROWSER}' == 'headlesschrome'  Open Test Browser Chrome  ${login_url}
     ...    ELSE IF  '${BROWSER}' == 'headlessfirefox'  Open Test Browser Headless Firefox  ${login_url}
     ...    ELSE  Open Browser  ${login_url}  ${BROWSER}
-    Sleep  2
     Wait Until Loading Is Complete
 
 Open Test Browser Chrome
@@ -63,4 +62,5 @@ Chrome Set Headless
     [Arguments]  ${options}
     Call Method  ${options}  set_headless  ${true}
     Call Method  ${options}  add_argument  --disable-dev-shm-usage
+    Call Method  ${options}  add_argument  --disable-background-timer-throttling
     [return]  ${options}


### PR DESCRIPTION
This adds a script which is run in the browser after each click to wait for any pending Aura XMLHTTPRequests to complete, to increase the chances of being ready for the next command.

I also removed some sleeps which seem to be no longer necessary. 

Other minor fixes:
- Return the result of a `_call_selenium` retry
- Increased selenium timeout to 30s
- Set Chrome's `--disable-background-timer-throttling` flag to avoid slowing things down when it's running in the background.