### PR TITLE
Update PyPI URL

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,7 @@ CumulusCI
 ===============================
 
 .. image:: https://img.shields.io/pypi/v/cumulusci.svg
-           :target: https://pypi.python.org/pypi/cumulusci
+           :target: https://pypi.org/project/cumulusci/
 .. image:: https://readthedocs.org/projects/cumulusci/badge/?version=latest
            :target: https://cumulusci.readthedocs.io/en/latest/?badge=latest
            :alt: Documentation Status

--- a/cumulusci/cli/cci.py
+++ b/cumulusci/cli/cci.py
@@ -86,7 +86,7 @@ def get_installed_version():
 def get_latest_version():
     """ return the latest version of cumulusci in pypi, be defensive """
     # use the pypi json api https://wiki.python.org/moin/PyPIJSON
-    res = requests.get('https://pypi.python.org/pypi/cumulusci/json', timeout=5).json()
+    res = requests.get('https://pypi.org/pypi/cumulusci/json', timeout=5).json()
     with dbm_cache() as cache:
         cache['cumulusci-latest-timestamp'] = str(time.time())
     return pkg_resources.parse_version(res['info']['version'])


### PR DESCRIPTION
The canonical domain for PyPI changed to pypi.org a few months ago. This should avoid getting redirected.