### PR TITLE
Be consistent about passing a keychain to refresh_oauth_token

### DIFF
--- a/cumulusci/core/config/ScratchOrgConfig.py
+++ b/cumulusci/core/config/ScratchOrgConfig.py
@@ -284,7 +284,7 @@ class ScratchOrgConfig(OrgConfig):
             message = 'Message: {}'.format('\n'.join(stdout_list))
             raise ScratchOrgException(message)
 
-    def refresh_oauth_token(self, keychain=None):
+    def refresh_oauth_token(self, keychain):
         """ Use sfdx force:org:describe to refresh token instead of built in OAuth handling """
         if hasattr(self, '_scratch_info'):
             # Cache the scratch_info for 1 hour to avoid unnecessary calls out

--- a/cumulusci/core/tests/test_config.py
+++ b/cumulusci/core/tests/test_config.py
@@ -822,7 +822,7 @@ class TestScratchOrgConfig(unittest.TestCase):
         config._scratch_info_date = datetime.now() - timedelta(days=1)
         config.force_refresh_oauth_token = mock.Mock()
 
-        config.refresh_oauth_token()
+        config.refresh_oauth_token(keychain=None)
 
         config.force_refresh_oauth_token.assert_called_once()
         self.assertTrue(config._scratch_info)

--- a/cumulusci/salesforce_api/metadata.py
+++ b/cumulusci/salesforce_api/metadata.py
@@ -178,7 +178,7 @@ class BaseMetadataApiCall(object):
         if faultcode == 'sf:INVALID_SESSION_ID' and self.task.org_config and self.task.org_config.refresh_token:
             # Attempt to refresh token and recall request
             if refresh:
-                self.task.org_config.refresh_oauth_token()
+                self.task.org_config.refresh_oauth_token(self.task.project_config.keychain)
                 return self._call_mdapi(headers, envelope, refresh=False)
         # Log the error
         message = '{}: {}'.format(faultcode, faultstring)

--- a/cumulusci/tests/util.py
+++ b/cumulusci/tests/util.py
@@ -62,5 +62,5 @@ class DummyOrgConfig(OrgConfig):
             name = 'test'
         super(DummyOrgConfig, self).__init__(config, name)
 
-    def refresh_oauth_token(self):
+    def refresh_oauth_token(self, keychain):
         pass


### PR DESCRIPTION
Previously, the refresh_oauth_token method did not require a keychain param for DummyOrgConfig and ScratchOrgConfig, but it did for OrgConfig. As a result, I think this token refresh in metadata.py would fail with a persistent org. This standardizes the interface to always pass a keychain.