### PR TITLE
Coverage for cumulus.cli.cci

### DIFF
--- a/cumulusci/cli/tests/test_cci.py
+++ b/cumulusci/cli/tests/test_cci.py
@@ -1,3 +1,4 @@
+from collections import OrderedDict
 from datetime import date
 import json
 import os
@@ -36,11 +37,11 @@ def run_click_command(cmd, *args, **kw):
 def recursive_list_files(d='.'):
     result = []
     for d, subdirs, files in os.walk(d):
-        d = d.replace(os.path.sep, '/')[2:]
-        if d:
-            result.append('/'.join([d, '']))
+        d = d.replace(os.path.sep, '/')
+        if d != '.':
+            result.append('/'.join([d, ''])[2:])
         for f in files:
-            result.append('/'.join([d, f]))
+            result.append('/'.join([d, f])[2:])
     result.sort()
     return result
 
@@ -136,10 +137,10 @@ class TestCCI(unittest.TestCase):
             })
         self.assertEqual("""\x1b[1mtest:\x1b[0m
     -
-        \x1b[1mdict:\x1b[0m
-            \x1b[1mkey:\x1b[0m value
         \x1b[1mlist:\x1b[0m
             - list
+        \x1b[1mdict:\x1b[0m
+            \x1b[1mkey:\x1b[0m value
         \x1b[1mstr:\x1b[0m str""", '\n'.join(out))
 
     @mock.patch('cumulusci.cli.cci.webbrowser')
@@ -224,6 +225,7 @@ class TestCCI(unittest.TestCase):
             run_click_command(cci.project_init, obj=config)
 
             # Make sure expected files/dirs were created
+            print recursive_list_files()
             self.assertEqual([
                 '.git/',
                 'cumulusci.yml',

--- a/cumulusci/cli/tests/test_cci.py
+++ b/cumulusci/cli/tests/test_cci.py
@@ -225,7 +225,6 @@ class TestCCI(unittest.TestCase):
             run_click_command(cci.project_init, obj=config)
 
             # Make sure expected files/dirs were created
-            print recursive_list_files()
             self.assertEqual([
                 '.git/',
                 'cumulusci.yml',

--- a/cumulusci/cli/tests/test_cci.py
+++ b/cumulusci/cli/tests/test_cci.py
@@ -36,11 +36,11 @@ def run_click_command(cmd, *args, **kw):
 def recursive_list_files(d='.'):
     result = []
     for d, subdirs, files in os.walk(d):
-        d = d[2:]
+        d = d.replace(os.path.sep, '/')[2:]
         if d:
-            result.append(os.path.join(d, ''))
+            result.append('/'.join(d, ''))
         for f in files:
-            result.append(os.path.join(d, f))
+            result.append('/'.join(d, f))
     result.sort()
     return result
 
@@ -127,11 +127,11 @@ class TestCCI(unittest.TestCase):
         with mock.patch('click.echo', out.append):
             cci.render_recursive({
                 'test': [
-                    {
-                        'list': ['list'],
-                        'dict': {'key': 'value'},
-                        'str': 'str',
-                    },
+                    OrderedDict((
+                        ('list', ['list']),
+                        ('dict', {'key': 'value'}),
+                        ('str', 'str'),
+                    )),
                 ]
             })
         self.assertEqual("""\x1b[1mtest:\x1b[0m
@@ -239,12 +239,16 @@ class TestCCI(unittest.TestCase):
                 'tests/standard_objects/create_contact.robot'
             ], recursive_list_files())
 
+            os.chdir('..')
+
     def test_project_init_no_git(self):
         with temporary_dir() as d:
             os.chdir(d)
 
             with self.assertRaises(click.ClickException):
                 run_click_command(cci.project_init)
+
+            os.chdir('..')
 
     def test_project_init_already_initted(self):
         with temporary_dir() as d:
@@ -255,6 +259,7 @@ class TestCCI(unittest.TestCase):
 
             with self.assertRaises(click.ClickException):
                 run_click_command(cci.project_init)
+            os.chdir('..')
 
     @mock.patch('click.echo')
     def test_project_info(self, echo):

--- a/cumulusci/cli/tests/test_cci.py
+++ b/cumulusci/cli/tests/test_cci.py
@@ -1,0 +1,891 @@
+from datetime import date
+import json
+import os
+import shutil
+import tempfile
+import time
+import unittest
+
+import click
+import mock
+import pkg_resources
+import requests
+import responses
+
+import cumulusci
+from cumulusci.core.config import OrgConfig
+from cumulusci.core.config import TaskConfig
+from cumulusci.core.tasks import BaseTask
+from cumulusci.core.exceptions import FlowNotFoundError
+from cumulusci.core.exceptions import OrgNotFound
+from cumulusci.core.exceptions import ScratchOrgException
+from cumulusci.core.exceptions import ServiceNotConfigured
+from cumulusci.core.exceptions import TaskNotFoundError
+from cumulusci.core.exceptions import TaskOptionsError
+from cumulusci.cli import cci
+from cumulusci.cli.config import CliConfig
+from cumulusci.tests.util import create_project_config
+from cumulusci.utils import temporary_dir
+
+def run_click_command(cmd, *args, **kw):
+    with click.Context(command=mock.Mock()) as ctx:
+        ctx.obj = kw.pop('obj', None)
+        result = cmd.callback(*args, **kw)
+        return ctx, result
+
+def recursive_list_files(d='.'):
+    result = []
+    for d, subdirs, files in os.walk(d):
+        d = d[2:]
+        if d:
+            result.append(os.path.join(d, ''))
+        for f in files:
+            result.append(os.path.join(d, f))
+    result.sort()
+    return result
+
+class TestCCI(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(self):
+        self.tempdir = tempfile.mkdtemp()
+        os.environ['HOME'] = self.tempdir
+
+    @classmethod
+    def tearDownClass(self):
+        shutil.rmtree(self.tempdir)
+
+    def test_dbm_cache(self):
+        with cci.dbm_cache() as cache:
+            cache['1'] = '1'
+        with cci.dbm_cache() as cache:
+            self.assertEqual('1', cache['1'])
+
+    def test_get_installed_version(self):
+        result = cci.get_installed_version()
+        self.assertEqual(cumulusci.__version__, result.base_version)
+
+    @responses.activate
+    def test_get_latest_version(self):
+        responses.add(
+            method='GET',
+            url='https://pypi.org/pypi/cumulusci/json',
+            body=json.dumps({'info': {'version': cumulusci.__version__}}),
+            status=200,
+        )
+        result = cci.get_latest_version()
+        self.assertEqual(cumulusci.__version__, result.base_version)
+
+    @mock.patch('cumulusci.cli.cci.get_installed_version')
+    @mock.patch('cumulusci.cli.cci.get_latest_version')
+    @mock.patch('cumulusci.cli.cci.click')
+    def test_check_latest_version(self, click, get_latest_version, get_installed_version):
+        with cci.dbm_cache() as cache:
+            cache['cumulusci-latest-timestamp'] = str(time.time() - 4000)
+        get_latest_version.return_value = pkg_resources.parse_version('2')
+        get_installed_version.return_value = pkg_resources.parse_version('1')
+
+        cci.check_latest_version()
+
+        self.assertEqual(2, click.echo.call_count)
+
+    @mock.patch('cumulusci.cli.cci.get_latest_version')
+    @mock.patch('cumulusci.cli.cci.click')
+    def test_check_latest_version_request_error(self, click, get_latest_version):
+        with cci.dbm_cache() as cache:
+            cache['cumulusci-latest-timestamp'] = str(time.time() - 4000)
+        get_latest_version.side_effect = requests.exceptions.RequestException()
+
+        cci.check_latest_version()
+
+        click.echo.assert_any_call('Error checking cci version:')
+
+    @mock.patch('pdb.post_mortem')
+    def test_handle_exception_debug(self, post_mortem):
+        cci.handle_exception_debug(config=None, debug=True)
+        post_mortem.assert_called()
+
+    def test_handle_exception_debug_throw(self):
+        throw = Exception()
+        try:
+            cci.handle_exception_debug(
+                config=None, debug=False, throw_exception=throw)
+        except Exception as err:
+            self.assertIs(throw, err)
+        else:
+            self.fail('Expected exception to be thrown.')
+
+    @mock.patch('cumulusci.cli.cci.handle_sentry_event')
+    def test_handle_exception_debug_sentry(self, handle_sentry_event):
+        _marker = object()
+        with self.assertRaises(Exception):
+            cci.handle_exception_debug(config=_marker, debug=False)
+        handle_sentry_event.assert_called_once_with(_marker, None)
+
+    def test_render_recursive(self):
+        out = []
+        with mock.patch('click.echo', out.append):
+            cci.render_recursive({
+                'test': [
+                    {
+                        'list': ['list'],
+                        'dict': {'key': 'value'},
+                        'str': 'str',
+                    },
+                ]
+            })
+        self.assertEqual("""\x1b[1mtest:\x1b[0m
+    -
+        \x1b[1mdict:\x1b[0m
+            \x1b[1mkey:\x1b[0m value
+        \x1b[1mlist:\x1b[0m
+            - list
+        \x1b[1mstr:\x1b[0m str""", '\n'.join(out))
+
+    @mock.patch('cumulusci.cli.cci.webbrowser')
+    @mock.patch('cumulusci.cli.cci.click')
+    def test_handle_sentry_event(self, click, webbrowser):
+        config = mock.Mock()
+        click.confirm.return_value = True
+
+        cci.handle_sentry_event(config, False)
+
+        webbrowser.open.assert_called_once()
+
+    def test_handle_sentry_event_no_event(self):
+        config = mock.Mock()
+        config.project_config.sentry_event = None
+
+        cci.handle_sentry_event(config, True)
+
+    @mock.patch('cumulusci.cli.cci.CliConfig')
+    @mock.patch('cumulusci.cli.cci.check_latest_version')
+    def test_main(self, check_latest_version, CliConfig):
+        CliConfig.return_value = _marker = object()
+
+        ctx, result = run_click_command(cci.main)
+
+        check_latest_version.assert_called_once()
+        self.assertIs(ctx.obj, _marker)
+
+    @mock.patch('cumulusci.cli.cci.CliConfig')
+    @mock.patch('cumulusci.cli.cci.check_latest_version')
+    def test_main_config_error(self, check_latest_version, CliConfig):
+        CliConfig.side_effect = click.UsageError('Broken!')
+        with self.assertRaises(SystemExit):
+            run_click_command(cci.main)
+
+    @mock.patch('click.echo')
+    def test_version(self, echo):
+        run_click_command(cci.version)
+        echo.assert_called_once_with(cumulusci.__version__)
+
+    @mock.patch('code.interact')
+    def test_shell(self, interact):
+        run_click_command(cci.shell)
+        interact.assert_called_once()
+        self.assertIn('config', interact.call_args[1]['local'])
+
+    def test_cover_command_groups(self):
+        run_click_command(cci.project)
+        run_click_command(cci.org)
+        run_click_command(cci.task)
+        run_click_command(cci.flow)
+        run_click_command(cci.service)
+        run_click_command(cci.service_connect)
+        # no assertion; this test is for coverage of empty methods
+
+    @mock.patch('cumulusci.cli.cci.click')
+    def test_project_init(self, click):
+        with temporary_dir() as d:
+            os.chdir(d)
+            os.mkdir('.git')
+
+            click.prompt.side_effect = (
+                'testproj',  # project_name
+                'testpkg',  # package_name
+                'testns',  # package_namespace
+                '43.0',  # api_version
+                '3',  # extend other URL
+                'https://github.com/SalesforceFoundation/Cumulus',  # github_url
+                'master',  # git_default_branch
+                'feature/',  # git_prefix_feature
+                'beta/',  # git_prefix_beta
+                'release/',  # git_prefix_release
+                '_TEST',  # test_name_match
+            )
+            click.confirm.side_effect = (
+                True,  # is managed?
+                True,  # extending?
+            )
+            config = mock.Mock()
+            config.global_config.project__test__name_match = '_TEST'
+
+            run_click_command(cci.project_init, obj=config)
+
+            # Make sure expected files/dirs were created
+            self.assertEqual([
+                '.git/',
+                'cumulusci.yml',
+                'orgs/',
+                'orgs/beta.json',
+                'orgs/dev.json',
+                'orgs/feature.json',
+                'orgs/release.json',
+                'sfdx-project.json',
+                'src/',
+                'tests/',
+                'tests/standard_objects/',
+                'tests/standard_objects/create_contact.robot'
+            ], recursive_list_files())
+
+    def test_project_init_no_git(self):
+        with temporary_dir() as d:
+            os.chdir(d)
+
+            with self.assertRaises(click.ClickException):
+                run_click_command(cci.project_init)
+
+    def test_project_init_already_initted(self):
+        with temporary_dir() as d:
+            os.chdir(d)
+            os.mkdir('.git')
+            with open('cumulusci.yml', 'w'):
+                pass  # create empty file
+
+            with self.assertRaises(click.ClickException):
+                run_click_command(cci.project_init)
+
+    @mock.patch('click.echo')
+    def test_project_info(self, echo):
+        config = mock.Mock()
+        config.project_config.project = {'test': 'test'}
+
+        run_click_command(cci.project_info, obj=config)
+
+        echo.assert_called_once_with('\x1b[1mtest:\x1b[0m test')
+
+    def test_project_dependencies(self):
+        out = []
+        config = mock.Mock()
+        config.project_config.pretty_dependencies.return_value = [
+            'test:',
+            '  headers: private',
+        ]
+
+        with mock.patch('click.echo', out.append):
+            run_click_command(cci.project_dependencies, obj=config)
+
+        self.assertEqual('test:', ''.join(out))
+
+    @mock.patch('click.echo')
+    def test_service_list(self, echo):
+        config = mock.Mock()
+        config.project_config.services = {'test': {'description': 'Test Service'}}
+        config.keychain.list_services.return_value = ['test']
+
+        run_click_command(cci.service_list, obj=config)
+
+        table = echo.call_args[0][0]
+        self.assertEqual("""service  description   is_configured
+-------  ------------  -------------
+test     Test Service  *""", str(table))
+
+    def test_service_connect_list(self):
+        multi_cmd = cci.ConnectServiceCommand()
+        config = mock.Mock()
+        config.project_config.services = {'test': {}}
+        ctx = mock.Mock()
+        ctx.ensure_object.return_value = config
+
+        result = multi_cmd.list_commands(ctx)
+        self.assertEqual(['test'], result)
+
+    def test_service_connect(self):
+        multi_cmd = cci.ConnectServiceCommand()
+        config = mock.Mock()
+        config.project_config.services__test__attributes = {
+            'attr': {
+                'required': False,
+            }
+        }
+        ctx = mock.Mock()
+        ctx.ensure_object.return_value = config
+
+        cmd = multi_cmd.get_command(ctx, 'test')
+        run_click_command(cmd, project=True)
+
+        config.keychain.set_service.assert_called_once()
+
+        run_click_command(cmd, project=False)
+
+    @mock.patch('click.echo')
+    def test_service_info(self, echo):
+        service_config = mock.Mock()
+        service_config.config = {
+            'description': 'Test Service'
+        }
+        config = mock.Mock()
+        config.keychain.get_service.return_value = service_config
+
+        run_click_command(cci.service_info, obj=config, service_name='test')
+
+        echo.assert_called_with('\x1b[1mdescription:\x1b[0m Test Service')
+
+    @mock.patch('click.echo')
+    def test_service_info_not_configured(self, echo):
+        config = mock.Mock()
+        config.keychain.get_service.side_effect = ServiceNotConfigured
+
+        run_click_command(cci.service_info, obj=config, service_name='test')
+
+        self.assertIn('not configured for this project', echo.call_args[0][0])
+
+    @mock.patch('webbrowser.open')
+    def test_org_browser(self, browser_open):
+        org_config = mock.Mock()
+        config = mock.Mock()
+        config.get_org.return_value = ('test', org_config)
+
+        run_click_command(cci.org_browser, obj=config, org_name='test')
+
+        org_config.refresh_oauth_token.assert_called_once()
+        browser_open.assert_called_once()
+        config.keychain.set_org.assert_called_once_with(org_config)
+
+    @responses.activate
+    @mock.patch('cumulusci.cli.cci.CaptureSalesforceOAuth')
+    def test_org_connect(self, oauth):
+        oauth.return_value = mock.Mock(return_value={
+            'instance_url': 'https://instance',
+            'access_token': 'BOGUS',
+        })
+        config = mock.Mock()
+        responses.add(
+            method='GET',
+            url='https://instance/services/oauth2/userinfo',
+            body=b'{}',
+            status=200,
+        )
+
+        run_click_command(
+            cci.org_connect, obj=config, org_name='test', sandbox=True,
+            login_url='https://login.salesforce.com', default=True, global_org=False)
+
+        config.check_org_overwrite.assert_called_once()
+        config.keychain.set_org.assert_called_once()
+        config.keychain.set_default_org.assert_called_once_with('test')
+
+    def test_org_connect_connected_app_not_configured(self):
+        config = mock.Mock()
+        config.keychain.get_service.side_effect = ServiceNotConfigured
+
+        with self.assertRaises(ServiceNotConfigured):
+            run_click_command(
+                cci.org_connect, obj=config, org_name='test', sandbox=True,
+                login_url='https://login.salesforce.com', default=True, global_org=False)
+
+    def test_org_default(self):
+        config = mock.Mock()
+
+        run_click_command(cci.org_default, obj=config, org_name='test', unset=False)
+
+        config.keychain.set_default_org.assert_called_once_with('test')
+
+    def test_org_default_unset(self):
+        config = mock.Mock()
+
+        run_click_command(cci.org_default, obj=config, org_name='test', unset=True)
+
+        config.keychain.unset_default_org.assert_called_once()
+
+    def test_org_info(self):
+        org_config = mock.Mock()
+        org_config.config = {'test': 'test'}
+        org_config.expires = date.today()
+        config = mock.Mock()
+        config.get_org.return_value = ('test', org_config)
+
+        out = []
+        with mock.patch('click.echo', out.append):
+            run_click_command(cci.org_info, obj=config, org_name='test', print_json=False)
+
+        org_config.refresh_oauth_token.assert_called_once()
+        self.assertTrue(''.join(out).startswith('\x1b[1mtest:\x1b[0m testOrg expires on '))
+        config.keychain.set_org.assert_called_once_with(org_config)
+
+    def test_org_info_json(self):
+        org_config = mock.Mock()
+        org_config.config = {'test': 'test'}
+        org_config.expires = date.today()
+        config = mock.Mock()
+        config.get_org.return_value = ('test', org_config)
+
+        out = []
+        with mock.patch('click.echo', out.append):
+            run_click_command(cci.org_info, obj=config, org_name='test', print_json=True)
+
+        org_config.refresh_oauth_token.assert_called_once()
+        self.assertEqual('{\n    "test": "test"\n}', ''.join(out))
+        config.keychain.set_org.assert_called_once_with(org_config)
+
+    @mock.patch('click.echo')
+    def test_org_list(self, echo):
+        config = mock.Mock()
+        config.project_config.list_orgs.return_value = ['test1', 'test2']
+        config.project_config.get_org.side_effect = [
+            OrgConfig({
+                'default': True,
+                'scratch': True,
+                'days_alive': 1,
+                'days': 7,
+                'expired': False,
+                'config_name': 'dev',
+                'username': 'test1@example.com',
+            }, 'test1'),
+            OrgConfig({
+                'default': False,
+                'scratch': False,
+                'expired': False,
+                'config_name': 'dev',
+                'username': 'test2@example.com',
+            }, 'test2'),
+        ]
+
+        run_click_command(cci.org_list, obj=config)
+
+        table = echo.call_args[0][0]
+        self.assertEqual("""org    default  scratch  days    expired  config_name  username
+-----  -------  -------  ------  -------  -----------  -----------------
+test1  *        *        1 of 7           dev          test1@example.com
+test2                                     dev          test2@example.com""", str(table))
+
+    def test_org_remove(self):
+        org_config = mock.Mock()
+        org_config.can_delete.return_value = True
+        config = mock.Mock()
+        config.keychain.get_org.return_value = org_config
+
+        run_click_command(cci.org_remove, obj=config, org_name='test', global_org=False)
+
+        org_config.delete_org.assert_called_once()
+        config.keychain.remove_org.assert_called_once_with('test', False)
+
+    @mock.patch('click.echo')
+    def test_org_remove_delete_error(self, echo):
+        org_config = mock.Mock()
+        org_config.can_delete.return_value = True
+        org_config.delete_org.side_effect = Exception
+        config = mock.Mock()
+        config.keychain.get_org.return_value = org_config
+
+        run_click_command(cci.org_remove, obj=config, org_name='test', global_org=False)
+
+        echo.assert_any_call('Deleting scratch org failed with error:')
+
+    def test_org_remove_not_found(self):
+        config = mock.Mock()
+        config.keychain.get_org.side_effect = OrgNotFound
+
+        with self.assertRaises(click.ClickException) as cm:
+            run_click_command(cci.org_remove, obj=config, org_name='test', global_org=False)
+
+        self.assertEqual('Org test does not exist in the keychain', str(cm.exception))
+
+    def test_org_scratch(self):
+        config = mock.Mock()
+        config.project_config.orgs__scratch = {
+            'dev': {
+                "orgName": "Dev",
+            }
+        }
+
+        run_click_command(
+            cci.org_scratch, obj=config, config_name='dev', org_name='test',
+            default=True, devhub='hub', days=7, no_password=True)
+
+        config.check_org_overwrite.assert_called_once()
+        config.keychain.create_scratch_org.assert_called_with(
+            'test', 'dev', 7, set_password=False
+        )
+        config.keychain.set_default_org.assert_called_with('test')
+
+    def test_org_scratch_no_configs(self):
+        config = mock.Mock()
+        config.project_config.orgs__scratch = None
+
+        with self.assertRaises(click.UsageError):
+            run_click_command(
+                cci.org_scratch, obj=config, config_name='dev', org_name='test',
+                default=True, devhub='hub', days=7, no_password=True)
+
+    def test_org_scratch_config_not_found(self):
+        config = mock.Mock()
+        config.project_config.orgs__scratch = {'bogus': {}}
+
+        with self.assertRaises(click.UsageError):
+            run_click_command(
+                cci.org_scratch, obj=config, config_name='dev', org_name='test',
+                default=True, devhub='hub', days=7, no_password=True)
+
+    def test_org_scratch_delete(self):
+        org_config = mock.Mock()
+        config = mock.Mock()
+        config.keychain.get_org.return_value = org_config
+
+        run_click_command(cci.org_scratch_delete, obj=config, org_name='test')
+
+        org_config.delete_org.assert_called_once()
+        config.keychain.set_org.assert_called_once_with(org_config)
+
+    def test_org_scratch_delete_not_scratch(self):
+        org_config = mock.Mock(scratch=False)
+        config = mock.Mock()
+        config.keychain.get_org.return_value = org_config
+
+        with self.assertRaises(click.UsageError):
+            run_click_command(cci.org_scratch_delete, obj=config, org_name='test')
+
+    def test_org_scratch_delete_error(self):
+        org_config = mock.Mock()
+        org_config.delete_org.side_effect = ScratchOrgException
+        config = mock.Mock()
+        config.keychain.get_org.return_value = org_config
+
+        with self.assertRaises(click.UsageError):
+            run_click_command(cci.org_scratch_delete, obj=config, org_name='test')
+
+    @mock.patch('click.echo')
+    def test_task_list(self, echo):
+        config = mock.Mock()
+        config.project_config.list_tasks.return_value = [
+            {
+                'name': 'test_task',
+                'description': 'Test Task',
+            }
+        ]
+
+        run_click_command(cci.task_list, obj=config)
+
+        config.check_project_config.assert_called_once()
+        table = echo.call_args[0][0]
+        self.assertEqual("""task       description
+---------  -----------
+test_task  Test Task""", str(table))
+
+    @mock.patch('cumulusci.cli.cci.doc_task')
+    def test_task_doc(self, doc_task):
+        config = mock.Mock()
+        config.global_config.tasks = {
+            'test': {},
+        }
+
+        run_click_command(cci.task_doc, obj=config)
+        doc_task.assert_called()
+
+    @mock.patch('cumulusci.cli.cci.rst2ansi')
+    @mock.patch('cumulusci.cli.cci.doc_task')
+    def test_task_info(self, doc_task, rst2ansi):
+        config = mock.Mock()
+        config.project_config.tasks__test = {
+            'options': {}
+        }
+
+        run_click_command(cci.task_info, obj=config, task_name='test')
+
+        config.check_project_config.assert_called_once()
+        doc_task.assert_called_once()
+        rst2ansi.assert_called_once()
+
+    def test_task_info_not_found(self):
+        config = mock.Mock()
+        config.project_config.tasks__test = None
+
+        with self.assertRaises(TaskNotFoundError):
+            run_click_command(cci.task_info, obj=config, task_name='test')
+
+    def test_task_run(self):
+        config = mock.Mock()
+        config.get_org.return_value = (None, None)
+        config.project_config.tasks__test = {
+            'class_path': 'cumulusci.cli.tests.test_cci.DummyTask'
+        }
+        DummyTask._run_task = mock.Mock()
+
+        run_click_command(
+            cci.task_run, obj=config, task_name='test', org=None, o=[('color', 'blue')],
+            debug=False, debug_before=False, debug_after=False, no_prompt=True)
+
+        config.check_keychain.assert_called_once()
+        DummyTask._run_task.assert_called_once()
+
+    def test_task_run_not_found(self):
+        config = mock.Mock()
+        config.get_org.return_value = (None, None)
+        config.project_config.tasks__test = None
+
+        with self.assertRaises(TaskNotFoundError):
+            run_click_command(
+                cci.task_run, obj=config, task_name='test', org=None, o=[('color', 'blue')],
+                debug=False, debug_before=False, debug_after=False, no_prompt=True)
+
+    def test_task_run_invalid_option(self):
+        config = mock.Mock()
+        config.get_org.return_value = (None, None)
+        config.project_config.tasks__test = {
+            'class_path': 'cumulusci.cli.tests.test_cci.DummyTask'
+        }
+
+        with self.assertRaises(click.UsageError):
+            run_click_command(
+                cci.task_run, obj=config, task_name='test', org=None, o=[('bogus', 'blue')],
+                debug=False, debug_before=False, debug_after=False, no_prompt=True)
+
+    @mock.patch('pdb.set_trace')
+    def test_task_run_debug_before(self, set_trace):
+        config = mock.Mock()
+        config.get_org.return_value = (None, None)
+        config.project_config.tasks__test = {
+            'class_path': 'cumulusci.cli.tests.test_cci.DummyTask'
+        }
+        set_trace.side_effect = SetTrace
+
+        with self.assertRaises(SetTrace):
+            run_click_command(
+                cci.task_run, obj=config, task_name='test', org=None, o=[('color', 'blue')],
+                debug=False, debug_before=True, debug_after=False, no_prompt=True)
+
+    @mock.patch('pdb.set_trace')
+    def test_task_run_debug_after(self, set_trace):
+        config = mock.Mock()
+        config.get_org.return_value = (None, None)
+        config.project_config.tasks__test = {
+            'class_path': 'cumulusci.cli.tests.test_cci.DummyTask'
+        }
+        set_trace.side_effect = SetTrace
+
+        with self.assertRaises(SetTrace):
+            run_click_command(
+                cci.task_run, obj=config, task_name='test', org=None, o=[('color', 'blue')],
+                debug=False, debug_before=False, debug_after=True, no_prompt=True)
+
+    def test_task_run_usage_error(self):
+        config = mock.Mock()
+        config.get_org.return_value = (None, None)
+        config.project_config.tasks__test = {
+            'class_path': 'cumulusci.cli.tests.test_cci.DummyTask'
+        }
+        DummyTask._run_task.side_effect = TaskOptionsError
+
+        with self.assertRaises(click.UsageError):
+            run_click_command(
+                cci.task_run, obj=config, task_name='test', org=None, o=[('color', 'blue')],
+                debug=False, debug_before=False, debug_after=False, no_prompt=True)
+
+    def test_task_run_expected_failure(self):
+        config = mock.Mock()
+        config.get_org.return_value = (None, None)
+        config.project_config.tasks__test = {
+            'class_path': 'cumulusci.cli.tests.test_cci.DummyTask'
+        }
+        DummyTask._run_task.side_effect = ScratchOrgException
+
+        with self.assertRaises(click.ClickException):
+            run_click_command(
+                cci.task_run, obj=config, task_name='test', org=None, o=[('color', 'blue')],
+                debug=False, debug_before=False, debug_after=False, no_prompt=True)
+
+    @mock.patch('cumulusci.cli.cci.handle_sentry_event')
+    def test_task_run_unexpected_exception(self, handle_sentry_event):
+        config = mock.Mock()
+        config.get_org.return_value = (None, None)
+        config.project_config.tasks__test = {
+            'class_path': 'cumulusci.cli.tests.test_cci.DummyTask'
+        }
+        DummyTask._run_task.side_effect = Exception
+
+        with self.assertRaises(Exception):
+            run_click_command(
+                cci.task_run, obj=config, task_name='test', org=None, o=[('color', 'blue')],
+                debug=False, debug_before=False, debug_after=False, no_prompt=True)
+
+        handle_sentry_event.assert_called_once()
+
+    @mock.patch('click.echo')
+    def test_flow_list(self, echo):
+        config = mock.Mock()
+        config.project_config.flows = ['test_flow']
+        config.project_config.flows__test_flow__description = 'Test Flow'
+
+        run_click_command(cci.flow_list, obj=config)
+
+        config.check_project_config.assert_called_once()
+        table = echo.call_args[0][0]
+        self.assertEqual("""flow       description
+---------  -----------
+test_flow  Test Flow""", str(table))
+
+    @mock.patch('click.echo')
+    def test_flow_info(self, echo):
+        config = mock.Mock()
+        config.project_config.flows__test = {'description': 'Test Flow'}
+
+        run_click_command(cci.flow_info, obj=config, flow_name='test')
+
+        config.check_project_config.assert_called_once()
+        echo.assert_called_with('\x1b[1mdescription:\x1b[0m Test Flow')
+
+    def test_flow_info_not_found(self):
+        config = mock.Mock()
+        config.project_config.flows__test = None
+
+        with self.assertRaises(FlowNotFoundError):
+            run_click_command(cci.flow_info, obj=config, flow_name='test')
+
+    def test_flow_run(self):
+        org_config = mock.Mock(scratch=True)
+        config = mock.Mock()
+        config.get_org.return_value = ('test', org_config)
+        config.project_config.flows__test = {
+            'steps': {
+                1: {
+                    'task': 'test_task'
+                }
+            }
+        }
+        config.project_config.get_task.return_value = TaskConfig({
+            'description': 'Test Task',
+            'class_path': 'cumulusci.cli.tests.test_cci.DummyTask'
+        })
+        DummyTask._run_task = mock.Mock()
+
+        run_click_command(
+            cci.flow_run, obj=config, flow_name='test', org='test', delete_org=True,
+            debug=False, o=[('test_task__color', 'blue')], skip=(), no_prompt=True)
+
+        config.check_keychain.assert_called_once()
+        DummyTask._run_task.assert_called_once()
+        org_config.delete_org.assert_called_once()
+
+    def test_flow_run_delete_non_scratch(self):
+        org_config = mock.Mock(scratch=False)
+        config = mock.Mock()
+        config.get_org.return_value = ('test', org_config)
+
+        with self.assertRaises(click.UsageError):
+            run_click_command(
+                cci.flow_run, obj=config, flow_name='test', org='test', delete_org=True,
+                debug=False, o=[('test_task__color', 'blue')], skip=(), no_prompt=True)
+
+    def test_flow_run_not_found(self):
+        org_config = mock.Mock()
+        config = mock.Mock()
+        config.get_org.return_value = ('test', org_config)
+        config.project_config.flows__test = {}
+
+        with self.assertRaises(click.UsageError):
+            run_click_command(
+                cci.flow_run, obj=config, flow_name='test', org='test', delete_org=False,
+                debug=False, o=[('test_task__color', 'blue')], skip=(), no_prompt=True)
+
+    def test_flow_run_usage_error(self):
+        org_config = mock.Mock()
+        config = mock.Mock()
+        config.get_org.return_value = ('test', org_config)
+        config.project_config.flows__test = {
+            'steps': {
+                1: {
+                    'task': 'test_task'
+                }
+            }
+        }
+        config.project_config.get_task.return_value = TaskConfig({
+            'description': 'Test Task',
+            'class_path': 'cumulusci.cli.tests.test_cci.DummyTask'
+        })
+        DummyTask._run_task = mock.Mock(side_effect=TaskOptionsError)
+
+        with self.assertRaises(click.UsageError):
+            run_click_command(
+                cci.flow_run, obj=config, flow_name='test', org='test', delete_org=False,
+                debug=False, o=[('test_task__color', 'blue')], skip=(), no_prompt=True)
+
+    def test_flow_run_expected_failure(self):
+        org_config = mock.Mock()
+        config = mock.Mock()
+        config.get_org.return_value = ('test', org_config)
+        config.project_config.flows__test = {
+            'steps': {
+                1: {
+                    'task': 'test_task'
+                }
+            }
+        }
+        config.project_config.get_task.return_value = TaskConfig({
+            'description': 'Test Task',
+            'class_path': 'cumulusci.cli.tests.test_cci.DummyTask'
+        })
+        DummyTask._run_task = mock.Mock(side_effect=ScratchOrgException)
+
+        with self.assertRaises(click.ClickException):
+            run_click_command(
+                cci.flow_run, obj=config, flow_name='test', org='test', delete_org=False,
+                debug=False, o=[('test_task__color', 'blue')], skip=(), no_prompt=True)
+
+    @mock.patch('cumulusci.cli.cci.handle_sentry_event')
+    def test_flow_run_unexpected_exception(self, handle_sentry_event):
+        org_config = mock.Mock()
+        config = mock.Mock()
+        config.get_org.return_value = ('test', org_config)
+        config.project_config.flows__test = {
+            'steps': {
+                1: {
+                    'task': 'test_task'
+                }
+            }
+        }
+        config.project_config.get_task.return_value = TaskConfig({
+            'description': 'Test Task',
+            'class_path': 'cumulusci.cli.tests.test_cci.DummyTask'
+        })
+        DummyTask._run_task = mock.Mock(side_effect=Exception)
+
+        with self.assertRaises(Exception):
+            run_click_command(
+                cci.flow_run, obj=config, flow_name='test', org='test', delete_org=False,
+                debug=False, o=[('test_task__color', 'blue')], skip=(), no_prompt=True)
+
+        handle_sentry_event.assert_called_once()
+
+    @mock.patch('click.echo')
+    def test_flow_run_org_delete_error(self, echo):
+        org_config = mock.Mock(scratch=True)
+        org_config.delete_org.side_effect = Exception
+        config = mock.Mock()
+        config.get_org.return_value = ('test', org_config)
+        config.project_config.flows__test = {
+            'steps': {
+                1: {
+                    'task': 'test_task'
+                }
+            }
+        }
+        config.project_config.get_task.return_value = TaskConfig({
+            'description': 'Test Task',
+            'class_path': 'cumulusci.cli.tests.test_cci.DummyTask'
+        })
+        DummyTask._run_task = mock.Mock()
+
+        run_click_command(
+            cci.flow_run, obj=config, flow_name='test', org='test', delete_org=True,
+            debug=False, o=[('test_task__color', 'blue')], skip=(), no_prompt=True)
+
+        echo.assert_any_call('Scratch org deletion failed.  Ignoring the error below to complete the flow:')
+
+class SetTrace(Exception):
+    pass
+
+class DummyTask(BaseTask):
+    task_options = {
+        'color': {}
+    }

--- a/cumulusci/cli/tests/test_cci.py
+++ b/cumulusci/cli/tests/test_cci.py
@@ -38,9 +38,9 @@ def recursive_list_files(d='.'):
     for d, subdirs, files in os.walk(d):
         d = d.replace(os.path.sep, '/')[2:]
         if d:
-            result.append('/'.join(d, ''))
+            result.append('/'.join([d, '']))
         for f in files:
-            result.append('/'.join(d, f))
+            result.append('/'.join([d, f]))
     result.sort()
     return result
 

--- a/cumulusci/core/config/OrgConfig.py
+++ b/cumulusci/core/config/OrgConfig.py
@@ -69,3 +69,6 @@ class OrgConfig(BaseConfig):
             self.instance_url + "/services/oauth2/userinfo", headers=headers)
         if response != self.config.get('userinfo', {}):
             self.config.update({'userinfo': response.json()})
+
+    def can_delete(self):
+        return False

--- a/cumulusci/core/config/ScratchOrgConfig.py
+++ b/cumulusci/core/config/ScratchOrgConfig.py
@@ -233,8 +233,11 @@ class ScratchOrgConfig(OrgConfig):
                     '\n'.join(stdout), '\n'.join(stderr))
             )
 
+    def can_delete(self):
+        return bool(self.date_created)
+
     def delete_org(self):
-        """ Uses sfdx force:org:delete to create the org """
+        """ Uses sfdx force:org:delete to delete the org """
         if not self.created:
             self.logger.info(
                 'Skipping org deletion: the scratch org has not been created')

--- a/cumulusci/core/tasks.py
+++ b/cumulusci/core/tasks.py
@@ -59,9 +59,9 @@ class BaseTask(object):
 
         if self.salesforce_task and not self.org_config:
             raise TaskRequiresSalesforceOrg(
-                'This task requires a Saleforce org_config but' +
-                ' none was passed to the Task constructor'
-            )
+                'This task requires a salesforce org. '
+                'Use org default <name> to set a default org '
+                'or pass the org name with the --org option')
         self._init_logger()
         self._init_options(kwargs)
         self._validate_options()


### PR DESCRIPTION
This one's a bit of a doozy. Some changes that warrant special attention:
- Moved global functions taking an initial 'config' param from cci.py to become methods of the CliConfig class
- Removed the unused 'e' arg for handle_exception_debug
- Made render_recursive handle lists better.
- Stop passing the return from render_recursive to click.echo, because it takes care of echoing itself.
- Make check_latest_version handle its own exceptions
- Removed unused --extend option for `project init`
- Removed unimplemented project_list and project_cd commands
- Don't echo scratch org expiration when using `org info` with the --json flag
- Delegate check for whether an org can be deleted to a `can_delete` method on the org config
- Remove unused --delete option for `org scratch`
- Fix exception handling for `org scratch_delete
- Simplify exception handling for `task run` and `flow run`