### PR TITLE
Add error handling for removeXmlElement

### DIFF
--- a/cumulusci/tests/test_utils.py
+++ b/cumulusci/tests/test_utils.py
@@ -107,6 +107,27 @@ class TestUtils(unittest.TestCase):
             )
             self.assertEqual(expected, result)
 
+    @mock.patch('xml.etree.ElementTree.parse')
+    def test_remove_xml_element_parse_error(self, mock_parse):
+        err = ET.ParseError()
+        err.msg = 'it broke'
+        err.lineno = 1
+        mock_parse.side_effect = err
+        with utils.temporary_dir() as d:
+            path = os.path.join(d, 'test.xml')
+            with open(path, 'w') as f:
+                f.write(
+                    '<?xml version="1.0" ?>'
+                    '<root xmlns="http://soap.sforce.com/2006/04/metadata">'
+                    '<tag>text</tag></root>'
+                )
+            try:
+                utils.removeXmlElement('tag', d, '*')
+            except ET.ParseError as err:
+                self.assertEqual(str(err), 'it broke (test.xml, line 1)')
+            else:
+                self.fail('Expected ParseError')
+
     def test_remove_xml_element_not_found(self):
         tree = ET.fromstring('<root />')
         result = utils.remove_xml_element('tag', tree)

--- a/cumulusci/utils.py
+++ b/cumulusci/utils.py
@@ -81,7 +81,7 @@ def removeXmlElement(name, directory, file_pattern, logger=None):
 def remove_xml_element_file(name, path):
     """ Remove XML elements from a single file """
     ET.register_namespace('', 'http://soap.sforce.com/2006/04/metadata')
-    tree = ET.parse(path)
+    tree = elementtree_parse_file(path)
     tree = remove_xml_element(name, tree)
     return tree.write(
         path,


### PR DESCRIPTION
From:
```python
  File "/Users/jestevez/.pyenv/versions/2.7.15/envs/cci/lib/python2.7/site-packages/cumulusci/core/flows.py", line 231, in _run_step
    self._run_task(stepnum, step_config)
  File "/Users/jestevez/.pyenv/versions/2.7.15/envs/cci/lib/python2.7/site-packages/cumulusci/core/flows.py", line 307, in _run_task
    raise e
xml.etree.ElementTree.ParseError: mismatched tag: line 3, column 6
```

To:

```python
  File "/Users/jestevez/projects/rel/CumulusCI/cumulusci/core/flows.py", line 231, in _run_step
    self._run_task(stepnum, step_config)
  File "/Users/jestevez/projects/rel/CumulusCI/cumulusci/core/flows.py", line 307, in _run_task
    raise e
xml.etree.ElementTree.ParseError: mismatched tag: line 3, column 6 (Account.object)
```