### PR TITLE
PyYAML 3.12 -> 3.13

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ plaintable==0.1.1
 pycrypto==2.6.1
 PyGithub==1.39
 pytz==2018.4
-PyYAML==3.12
+PyYAML==3.13
 raven==6.7.0
 requests[security]==2.18.4
 responses==0.9.0

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ requirements = [
     'pycrypto==2.6.1',
     'PyGithub==1.39',
     'pytz==2018.4',
-    'PyYAML==3.12',
+    'PyYAML==3.13',
     'raven==6.7.0',
     'requests[security]==2.18.4',
     'responses==0.9.0',


### PR DESCRIPTION
Installing metaci_cli is currently failing due to a mismatch between CumulusCI's dependency on PyYAML being set to an older version.

Increase to 3.13 to resolve.