### PR TITLE
set client id in call options

### DIFF
--- a/cumulusci/tasks/salesforce/BaseSalesforceApiTask.py
+++ b/cumulusci/tasks/salesforce/BaseSalesforceApiTask.py
@@ -3,6 +3,7 @@ from simple_salesforce import Salesforce
 
 from cumulusci.tasks.salesforce import BaseSalesforceTask
 
+CALL_OPTS_HEADER_KEY = 'Sforce-Call-Options'
 
 class BaseSalesforceApiTask(BaseSalesforceTask):
     name = 'BaseSalesforceApiTask'
@@ -13,7 +14,6 @@ class BaseSalesforceApiTask(BaseSalesforceTask):
         self.bulk = self._init_bulk()
         self.tooling = self._init_api('tooling/')
         self._init_class()
-    
 
     def _init_api(self, base_url=None):
         if self.api_version:
@@ -28,6 +28,9 @@ class BaseSalesforceApiTask(BaseSalesforceTask):
         )
         if base_url is not None:
             rv.base_url += base_url
+
+        rv.headers.setdefault(CALL_OPTS_HEADER_KEY, self._get_client_name())
+
         return rv
 
     def _init_bulk(self):

--- a/cumulusci/tasks/salesforce/BaseSalesforceApiTask.py
+++ b/cumulusci/tasks/salesforce/BaseSalesforceApiTask.py
@@ -29,7 +29,7 @@ class BaseSalesforceApiTask(BaseSalesforceTask):
         if base_url is not None:
             rv.base_url += base_url
 
-        rv.headers.setdefault(CALL_OPTS_HEADER_KEY, self._get_client_name())
+        rv.headers.setdefault(CALL_OPTS_HEADER_KEY, "client={}".format(self._get_client_name()))
 
         return rv
 

--- a/cumulusci/tasks/salesforce/BaseSalesforceTask.py
+++ b/cumulusci/tasks/salesforce/BaseSalesforceTask.py
@@ -1,9 +1,19 @@
 from cumulusci.core.tasks import BaseTask
+from cumulusci.core.exceptions import ServiceNotValid, ServiceNotConfigured
+from cumulusci import __version__
 
 
 class BaseSalesforceTask(BaseTask):
     name = 'BaseSalesforceTask'
     salesforce_task = True
+
+    def _get_client_name(self):
+        try:
+            app = self.project_config.keychain.get_service('connectedapp')
+            return app.client_id
+        except (ServiceNotValid, ServiceNotConfigured):
+            return 'CumulusCI/{}'.format(__version__)
+
 
     def _run_task(self):
         raise NotImplementedError(

--- a/cumulusci/tasks/tests/test_bulkdata.py
+++ b/cumulusci/tasks/tests/test_bulkdata.py
@@ -10,6 +10,7 @@ import responses
 from cumulusci.core.config import BaseGlobalConfig
 from cumulusci.core.config import BaseProjectConfig
 from cumulusci.core.config import TaskConfig
+from cumulusci.core.keychain import BaseProjectKeychain
 from cumulusci.tasks import bulkdata
 from cumulusci.tests.util import DummyOrgConfig
 from cumulusci.utils import temporary_dir
@@ -34,6 +35,8 @@ def _make_task(task_class, task_config):
     task_config = TaskConfig(task_config)
     global_config = BaseGlobalConfig()
     project_config = BaseProjectConfig(global_config)
+    keychain = BaseProjectKeychain(project_config, '')
+    project_config.set_keychain(keychain)
     org_config = DummyOrgConfig({
         'instance_url': 'example.com',
         'access_token': 'abc123',


### PR DESCRIPTION
For all SimpleSalesforce instances we summon up, set the Sforce-Call-Options header to include a client id when registered or the CumulusCI clientName.