### PR TITLE
Don't support dynamic flowrunner

### DIFF
--- a/cumulusci/cli/cci.py
+++ b/cumulusci/cli/cci.py
@@ -41,6 +41,7 @@ from cumulusci.core.exceptions import ConfigError
 from cumulusci.core.exceptions import FlowNotFoundError
 from cumulusci.core.exceptions import KeychainKeyNotFound
 from cumulusci.core.exceptions import OrgNotFound
+from cumulusci.core.flows import BaseFlow
 from cumulusci.salesforce_api.exceptions import MetadataApiError
 from cumulusci.salesforce_api.exceptions import MetadataComponentFailure
 from cumulusci.core.exceptions import NotInProject
@@ -857,11 +858,6 @@ def flow_run(config, flow_name, org, delete_org, debug, o, skip, no_prompt):
             'No configuration found for flow {}'.format(flow_name))
     flow_config = FlowConfig(flow)
 
-    # Get the class to look up options
-    class_path = flow_config.config.get(
-        'class_path', 'cumulusci.core.flows.BaseFlow')
-    flow_class = import_class(class_path)
-
     # Parse command line options and add to task config
     options = {}
     if o:
@@ -870,7 +866,7 @@ def flow_run(config, flow_name, org, delete_org, debug, o, skip, no_prompt):
 
     # Create the flow and handle initialization exceptions
     try:
-        flow = flow_class(config.project_config, flow_config,
+        flow = BaseFlow(config.project_config, flow_config,
                           org_config, options, skip, name=flow_name)
 
         flow()

--- a/cumulusci/core/flows.py
+++ b/cumulusci/core/flows.py
@@ -231,14 +231,11 @@ class BaseFlow(object):
             self._run_task(stepnum, step_config)
 
     def _run_flow(self, stepnum, step_config):
-        class_path = step_config['flow_config'].config.get(
-            'class_path',
-            'cumulusci.core.flows.BaseFlow',
-        )
         flow_options = step_config['step_config'].get(
             'options',
             {},
         )
+
         if flow_options:
             # Collapse down flow options into task__option format to pass
             options = {}
@@ -247,8 +244,7 @@ class BaseFlow(object):
                     options['{}__{}'.format(task, option)] = value
             flow_options = options
                 
-        flow_class = import_class(class_path)
-        flow = flow_class(
+        flow = self.__class__(
             self.project_config,
             step_config['flow_config'],
             self.org_config,

--- a/cumulusci/core/flows.py
+++ b/cumulusci/core/flows.py
@@ -17,7 +17,9 @@ from cumulusci.core.utils import import_class
 
 
 class BaseFlow(object):
-    """ BaseFlow handles initializing and running a flow """
+    """ BaseFlow handles initializing and running a flow.
+
+    This can be subclassed by the execution environment to override pre_flow/pre_task etc hooks. """
 
     def __init__(
             self,


### PR DESCRIPTION
Instead of allowing a FlowConfig to define a flowrunner class_path, the flowrunner class is determined by the execution environment. Subflows inherit the flowrunner from their parent. 

There's presumably some work we can do in cumulusci.cli for a cli specific flowrunner, but now all CLI flow invocations will use BaseFlow. MetaCI will continue to use its custom MetaCIFlow and now child flows will too.