### PR TITLE
New Flow: retrieve_scratch

### DIFF
--- a/cumulusci/cumulusci.yml
+++ b/cumulusci/cumulusci.yml
@@ -57,7 +57,7 @@ tasks:
         description: Converts force-app directory in sfdx format into metadata format under src
         class_path: cumulusci.tasks.sfdx.SFDXBaseTask
         options:
-            command: 'force:mdapi:convert -r force-app -d src'
+            command: 'force:source:convert -d src'
     dx_pull:
         description: Uses sfdx to pull from a scratch org into the force-app directory
         class_path: cumulusci.tasks.sfdx.SFDXOrgTask
@@ -501,6 +501,18 @@ flows:
                 options:
                     publish: True
                     tag: ^^github_release.tag_name
+
+    retrieve_scratch:
+        description: Retrieves declarative changes made in a scratch org and converts to src directory
+        steps:
+            1:
+                task: dx_convert_to
+            2:
+                task: dx_pull
+            3:
+                task: dx_convert_from
+            4:
+                task: update_package_xml
 
     unmanaged_ee:
         description: Deploy the unmanaged package metadata and all dependencies to the target EE org

--- a/cumulusci/tasks/command.py
+++ b/cumulusci/tasks/command.py
@@ -75,7 +75,7 @@ class Command(BaseTask):
         return env
 
     def _process_output(self, line):
-        self.logger.info(line.rstrip())
+        self.logger.info(line.decode('utf-8').rstrip())
 
     def _handle_returncode(self, returncode, stderr):
         if returncode:


### PR DESCRIPTION
- Add new flow `retrieve_scratch` to retrieve declarative changes from  scratch org via sfdx force:source:pull and convert to src directory via sfdx force:source:convert
- Decode command output as utf-8 in Command task

One drawback is that it reorders some of the elements in .object files.  It moves the `<fields>` elements to the end rather than keeping in alphabetical order.

Another drawback is that it outputs a lot of log lines but that's minor.